### PR TITLE
INTYGFV-16343: Logic to handle requirements relating to protected persons when creating and retrieving certificates.

### DIFF
--- a/certificate-service/app/src/test/java/se/inera/intyg/certificateservice/application/common/ActionEvaluationFactoryTest.java
+++ b/certificate-service/app/src/test/java/se/inera/intyg/certificateservice/application/common/ActionEvaluationFactoryTest.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.ALVE_REACT_ALFREDSSON_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.ATHENA_REACT_ANDERSSON_DTO;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.ATLAS_REACT_ABRAHAMSSON_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.athenaReactAnderssonDtoBuilder;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_ALLERGIMOTTAGNINGEN_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_MEDICINCENTRUM_DTO;
@@ -504,7 +504,7 @@ class ActionEvaluationFactoryTest {
     @Test
     void shallIncludePatientDeceasedTrue() {
       final var actionEvaluation = actionEvaluationFactory.create(
-          ALVE_REACT_ALFREDSSON_DTO,
+          ATLAS_REACT_ABRAHAMSSON_DTO,
           AJLA_DOCTOR_DTO,
           ALFA_ALLERGIMOTTAGNINGEN_DTO,
           ALFA_MEDICINCENTRUM_DTO,

--- a/certificate-service/app/src/testFixtures/java/se/inera/intyg/certificateservice/application/testdata/TestDataCommonPatientDTO.java
+++ b/certificate-service/app/src/testFixtures/java/se/inera/intyg/certificateservice/application/testdata/TestDataCommonPatientDTO.java
@@ -11,6 +11,17 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientC
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ALVE_REACT_ALFREDSSON_STREET;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ALVE_REACT_ALFREDSSON_TEST_INDICATED;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ALVE_REACT_ALFREDSSON_ZIP_CODE;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_CITY;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_DECEASED;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_FIRST_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_FULL_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_ID;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_LAST_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_MIDDLE_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_PROTECTED_PERSON;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_STREET;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_TEST_INDICATED;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ANONYMA_REACT_ATTILA_ZIP_CODE;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_CITY;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_DECEASED;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_FIRST_NAME;
@@ -22,6 +33,17 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientC
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_STREET;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_TEST_INDICATED;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_ZIP_CODE;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_CITY;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_DECEASED;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_FIRST_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_FULL_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_ID;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_LAST_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_MIDDLE_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_PROTECTED_PERSON;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_STREET;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_TEST_INDICATED;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_ZIP_CODE;
 
 import se.inera.intyg.certificateservice.application.common.dto.PatientDTO;
 import se.inera.intyg.certificateservice.application.common.dto.PatientDTO.PatientDTOBuilder;
@@ -32,6 +54,8 @@ public class TestDataCommonPatientDTO {
 
   public static final PatientDTO ATHENA_REACT_ANDERSSON_DTO = athenaReactAnderssonDtoBuilder().build();
   public static final PatientDTO ALVE_REACT_ALFREDSSON_DTO = alveReactAlfredssonDtoBuilder().build();
+  public static final PatientDTO ATLAS_REACT_ABRAHAMSSON_DTO = atlasReactAbrahamssonDtoBuilder().build();
+  public static final PatientDTO ANONYMA_REACT_ATTILA_DTO = anonymaReactAttilaDtoBuilder().build();
 
   public static PatientDTOBuilder athenaReactAnderssonDtoBuilder() {
     return PatientDTO.builder()
@@ -71,5 +95,45 @@ public class TestDataCommonPatientDTO {
         .deceased(ALVE_REACT_ALFREDSSON_DECEASED.value())
         .protectedPerson(ALVE_REACT_ALFREDSSON_PROTECTED_PERSON.value())
         .testIndicated(ALVE_REACT_ALFREDSSON_TEST_INDICATED.value());
+  }
+
+  public static PatientDTOBuilder atlasReactAbrahamssonDtoBuilder() {
+    return PatientDTO.builder()
+        .id(
+            PersonIdDTO.builder()
+                .type(PersonIdTypeDTO.PERSONAL_IDENTITY_NUMBER)
+                .id(ATLAS_REACT_ABRAHAMSSON_ID)
+                .build()
+        )
+        .city(ATLAS_REACT_ABRAHAMSSON_CITY)
+        .street(ATLAS_REACT_ABRAHAMSSON_STREET)
+        .zipCode(ATLAS_REACT_ABRAHAMSSON_ZIP_CODE)
+        .firstName(ATLAS_REACT_ABRAHAMSSON_FIRST_NAME)
+        .lastName(ATLAS_REACT_ABRAHAMSSON_LAST_NAME)
+        .middleName(ATLAS_REACT_ABRAHAMSSON_MIDDLE_NAME)
+        .fullName(ATLAS_REACT_ABRAHAMSSON_FULL_NAME)
+        .deceased(ATLAS_REACT_ABRAHAMSSON_DECEASED.value())
+        .protectedPerson(ATLAS_REACT_ABRAHAMSSON_PROTECTED_PERSON.value())
+        .testIndicated(ATLAS_REACT_ABRAHAMSSON_TEST_INDICATED.value());
+  }
+
+  public static PatientDTOBuilder anonymaReactAttilaDtoBuilder() {
+    return PatientDTO.builder()
+        .id(
+            PersonIdDTO.builder()
+                .type(PersonIdTypeDTO.PERSONAL_IDENTITY_NUMBER)
+                .id(ANONYMA_REACT_ATTILA_ID)
+                .build()
+        )
+        .city(ANONYMA_REACT_ATTILA_CITY)
+        .street(ANONYMA_REACT_ATTILA_STREET)
+        .zipCode(ANONYMA_REACT_ATTILA_ZIP_CODE)
+        .firstName(ANONYMA_REACT_ATTILA_FIRST_NAME)
+        .lastName(ANONYMA_REACT_ATTILA_LAST_NAME)
+        .middleName(ANONYMA_REACT_ATTILA_MIDDLE_NAME)
+        .fullName(ANONYMA_REACT_ATTILA_FULL_NAME)
+        .deceased(ANONYMA_REACT_ATTILA_DECEASED.value())
+        .protectedPerson(ANONYMA_REACT_ATTILA_PROTECTED_PERSON.value())
+        .testIndicated(ANONYMA_REACT_ATTILA_TEST_INDICATED.value());
   }
 }

--- a/certificate-service/app/src/testFixtures/java/se/inera/intyg/certificateservice/application/testdata/TestDataCommonUserDTO.java
+++ b/certificate-service/app/src/testFixtures/java/se/inera/intyg/certificateservice/application/testdata/TestDataCommonUserDTO.java
@@ -4,6 +4,10 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserCons
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.AJLA_DOCTOR_HSA_ID;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.AJLA_DOCTOR_NAME;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.AJLA_DOCTOR_ROLE;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_BLOCKED;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_HSA_ID;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_ROLE;
 
 import se.inera.intyg.certificateservice.application.common.dto.RoleTypeDTO;
 import se.inera.intyg.certificateservice.application.common.dto.UserDTO;
@@ -12,6 +16,7 @@ import se.inera.intyg.certificateservice.application.common.dto.UserDTO.UserDTOB
 public class TestDataCommonUserDTO {
 
   public static final UserDTO AJLA_DOCTOR_DTO = ajlaDoktorDtoBuilder().build();
+  public static final UserDTO ALVA_VARDADMINISTRATOR_DTO = alvaVardadministratorDtoBuilder().build();
 
   public static UserDTOBuilder ajlaDoktorDtoBuilder() {
     return UserDTO.builder()
@@ -19,5 +24,13 @@ public class TestDataCommonUserDTO {
         .name(AJLA_DOCTOR_NAME)
         .role(RoleTypeDTO.toRoleType(AJLA_DOCTOR_ROLE))
         .blocked(AJLA_DOCTOR_BLOCKED.value());
+  }
+
+  public static UserDTOBuilder alvaVardadministratorDtoBuilder() {
+    return UserDTO.builder()
+        .id(ALVA_VARDADMINISTRATOR_HSA_ID)
+        .name(ALVA_VARDADMINISTRATOR_NAME)
+        .role(RoleTypeDTO.toRoleType(ALVA_VARDADMINISTRATOR_ROLE))
+        .blocked(ALVA_VARDADMINISTRATOR_BLOCKED.value());
   }
 }

--- a/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreate.java
+++ b/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreate.java
@@ -49,8 +49,7 @@ public class CertificateActionCreate implements CertificateAction {
   }
 
   private static boolean isUserNotBlocked(ActionEvaluation actionEvaluation) {
-    return !actionEvaluation.getUser()
-        .getBlocked().value();
+    return !actionEvaluation.getUser().getBlocked().value();
   }
 
   private static boolean isPatientAlive(ActionEvaluation actionEvaluation) {

--- a/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreate.java
+++ b/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreate.java
@@ -26,12 +26,10 @@ public class CertificateActionCreate implements CertificateAction {
     if (actionEvaluation.getPatient() == null || actionEvaluation.getUser() == null) {
       return false;
     }
-    if (Role.CARE_ADMIN.equals(actionEvaluation.getUser().getRole())
-        && actionEvaluation.getPatient().getProtectedPerson().value()) {
+    if (isPatientProtectedPersonAndUserHasRoleCareAdmin(actionEvaluation)) {
       return false;
     }
-    return !actionEvaluation.getPatient().getDeceased().value() && !actionEvaluation.getUser()
-        .getBlocked().value();
+    return isPatientAlive(actionEvaluation) && isUserNotBlocked(actionEvaluation);
   }
 
   @Override
@@ -42,5 +40,20 @@ public class CertificateActionCreate implements CertificateAction {
   @Override
   public String getDescription() {
     return DESCRIPTION;
+  }
+
+  private static boolean isPatientProtectedPersonAndUserHasRoleCareAdmin(
+      ActionEvaluation actionEvaluation) {
+    return Role.CARE_ADMIN.equals(actionEvaluation.getUser().getRole())
+        && actionEvaluation.getPatient().getProtectedPerson().value();
+  }
+
+  private static boolean isUserNotBlocked(ActionEvaluation actionEvaluation) {
+    return !actionEvaluation.getUser()
+        .getBlocked().value();
+  }
+
+  private static boolean isPatientAlive(ActionEvaluation actionEvaluation) {
+    return !actionEvaluation.getPatient().getDeceased().value();
   }
 }

--- a/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreate.java
+++ b/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreate.java
@@ -3,6 +3,7 @@ package se.inera.intyg.certificateservice.domain.action.model;
 import java.util.Optional;
 import se.inera.intyg.certificateservice.domain.certificate.model.Certificate;
 import se.inera.intyg.certificateservice.domain.certificatemodel.model.CertificateActionSpecification;
+import se.inera.intyg.certificateservice.domain.user.model.Role;
 
 public class CertificateActionCreate implements CertificateAction {
 
@@ -23,6 +24,10 @@ public class CertificateActionCreate implements CertificateAction {
   @Override
   public boolean evaluate(Optional<Certificate> certificate, ActionEvaluation actionEvaluation) {
     if (actionEvaluation.getPatient() == null || actionEvaluation.getUser() == null) {
+      return false;
+    }
+    if (Role.CARE_ADMIN.equals(actionEvaluation.getUser().getRole())
+        && actionEvaluation.getPatient().getProtectedPerson().value()) {
       return false;
     }
     return !actionEvaluation.getPatient().getDeceased().value() && !actionEvaluation.getUser()

--- a/certificate-service/domain/src/test/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreateTest.java
+++ b/certificate-service/domain/src/test/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionCreateTest.java
@@ -3,9 +3,11 @@ package se.inera.intyg.certificateservice.domain.action.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ALVE_REACT_ALFREDSSON;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ANONYMA_REACT_ATTILA;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ATHENA_REACT_ANDERSSON;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ATLAS_REACT_ABRAHAMSSON;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUser.AJLA_DOKTOR;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUser.ALVA_VARDADMINISTRATOR;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUser.ajlaDoctorBuilder;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.BLOCKED_TRUE;
 
@@ -45,7 +47,7 @@ class CertificateActionCreateTest {
   @Test
   void shallReturnFalseIfPatientIsDeceased() {
     final var actionEvaluation = ActionEvaluation.builder()
-        .patient(ALVE_REACT_ALFREDSSON)
+        .patient(ATLAS_REACT_ABRAHAMSSON)
         .user(AJLA_DOKTOR)
         .build();
 
@@ -86,6 +88,30 @@ class CertificateActionCreateTest {
   void shallReturnTrueIfUserIsNotBlocked() {
     final var actionEvaluation = ActionEvaluation.builder()
         .patient(ATHENA_REACT_ANDERSSON)
+        .user(AJLA_DOKTOR)
+        .build();
+
+    final var actualResult = certificateActionCreate.evaluate(actionEvaluation);
+
+    assertTrue(actualResult);
+  }
+
+  @Test
+  void shallReturnFalseIfUserIsCareAdminAndPatientIsProtectedPerson() {
+    final var actionEvaluation = ActionEvaluation.builder()
+        .patient(ANONYMA_REACT_ATTILA)
+        .user(ALVA_VARDADMINISTRATOR)
+        .build();
+
+    final var actualResult = certificateActionCreate.evaluate(actionEvaluation);
+
+    assertFalse(actualResult);
+  }
+
+  @Test
+  void shallReturnTrueIfUserIsDoctorAndPatientIsProtectedPerson() {
+    final var actionEvaluation = ActionEvaluation.builder()
+        .patient(ANONYMA_REACT_ATTILA)
         .user(AJLA_DOKTOR)
         .build();
 

--- a/certificate-service/domain/src/test/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionReadTest.java
+++ b/certificate-service/domain/src/test/java/se/inera/intyg/certificateservice/domain/action/model/CertificateActionReadTest.java
@@ -7,11 +7,13 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareProv
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnit.ALFA_MEDICINCENTRUM;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnitConstants.ALFA_MEDICINCENTRUM_ID;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnitConstants.ALFA_VARDCENTRAL_ID;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ANONYMA_REACT_ATTILA;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ATHENA_REACT_ANDERSSON;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataSubUnit.ALFA_ALLERGIMOTTAGNINGEN;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataSubUnitConstants.ALFA_ALLERGIMOTTAGNINGEN_ID;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataSubUnitConstants.ALFA_HUDMOTTAGNINGEN_ID;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUser.AJLA_DOKTOR;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUser.ALVA_VARDADMINISTRATOR;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,9 +49,7 @@ class CertificateActionReadTest {
         );
     actionEvaluationBuilder = ActionEvaluation.builder()
         .user(AJLA_DOKTOR)
-        .subUnit(
-            SubUnit.builder().build()
-        )
+        .subUnit(ALFA_ALLERGIMOTTAGNINGEN)
         .patient(ATHENA_REACT_ANDERSSON)
         .careProvider(ALFA_REGIONEN)
         .careUnit(ALFA_MEDICINCENTRUM);
@@ -140,6 +140,50 @@ class CertificateActionReadTest {
     assertFalse(
         certificateActionRead.evaluate(Optional.of(certificate), actionEvaluation),
         () -> "Expected false when passing %s and %s".formatted(actionEvaluation, certificate)
+    );
+  }
+
+  @Test
+  void shallReturnFalseIfUserIsCareAdminAndPatientIsProtectedPerson() {
+    final var actionEvaluation = actionEvaluationBuilder
+        .user(ALVA_VARDADMINISTRATOR)
+        .build();
+
+    final var certificate = certificateBuilder
+        .certificateMetaData(
+            CertificateMetaData.builder()
+                .issuingUnit(ALFA_ALLERGIMOTTAGNINGEN)
+                .careUnit(ALFA_MEDICINCENTRUM)
+                .careProvider(ALFA_REGIONEN)
+                .patient(ANONYMA_REACT_ATTILA)
+                .build()
+        )
+        .build();
+
+    assertFalse(
+        certificateActionRead.evaluate(Optional.of(certificate), actionEvaluation),
+        () -> "Expected false when passing %s and %s".formatted(actionEvaluation, certificate)
+    );
+  }
+
+  @Test
+  void shallReturnTrueIfUserIsDoctorAndPatientIsProtectedPerson() {
+    final var actionEvaluation = actionEvaluationBuilder.build();
+
+    final var certificate = certificateBuilder
+        .certificateMetaData(
+            CertificateMetaData.builder()
+                .issuingUnit(ALFA_ALLERGIMOTTAGNINGEN)
+                .careUnit(ALFA_MEDICINCENTRUM)
+                .careProvider(ALFA_REGIONEN)
+                .patient(ANONYMA_REACT_ATTILA)
+                .build()
+        )
+        .build();
+
+    assertTrue(
+        certificateActionRead.evaluate(Optional.of(certificate), actionEvaluation),
+        () -> "Expected true when passing %s and %s".formatted(actionEvaluation, certificate)
     );
   }
 }

--- a/certificate-service/domain/src/test/java/se/inera/intyg/certificateservice/domain/certificate/model/CertificateTest.java
+++ b/certificate-service/domain/src/test/java/se/inera/intyg/certificateservice/domain/certificate/model/CertificateTest.java
@@ -21,8 +21,8 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnit
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnitConstants.ALFA_VARDCENTRAL_NAME;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnitConstants.ALFA_VARDCENTRAL_PHONENUMBER;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataCareUnitConstants.ALFA_VARDCENTRAL_ZIP_CODE;
-import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ALVE_REACT_ALFREDSSON;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ATHENA_REACT_ANDERSSON;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.ATLAS_REACT_ABRAHAMSSON;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatient.athenaReactAnderssonBuilder;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.ATHENA_REACT_ANDERSSON_ID;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPatientConstants.DECEASED_TRUE;
@@ -127,13 +127,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .id(ALVE_REACT_ALFREDSSON.getId())
+                        .id(ATLAS_REACT_ABRAHAMSSON.getId())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getId().getId(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getId().getId(),
             certificate.certificateMetaData().getPatient().getId().getId());
       }
 
@@ -143,13 +143,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .name(ALVE_REACT_ALFREDSSON.getName())
+                        .name(ATLAS_REACT_ABRAHAMSSON.getName())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getName().getFirstName(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getName().getFirstName(),
             certificate.certificateMetaData().getPatient().getName().getFirstName()
         );
       }
@@ -160,13 +160,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .name(ALVE_REACT_ALFREDSSON.getName())
+                        .name(ATLAS_REACT_ABRAHAMSSON.getName())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getName().getMiddleName(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getName().getMiddleName(),
             certificate.certificateMetaData().getPatient().getName().getMiddleName());
       }
 
@@ -176,13 +176,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .name(ALVE_REACT_ALFREDSSON.getName())
+                        .name(ATLAS_REACT_ABRAHAMSSON.getName())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getName().getLastName(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getName().getLastName(),
             certificate.certificateMetaData().getPatient().getName().getLastName());
       }
 
@@ -192,13 +192,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .address(ALVE_REACT_ALFREDSSON.getAddress())
+                        .address(ATLAS_REACT_ABRAHAMSSON.getAddress())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getAddress().getCity(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getAddress().getCity(),
             certificate.certificateMetaData().getPatient().getAddress().getCity());
       }
 
@@ -208,13 +208,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .address(ALVE_REACT_ALFREDSSON.getAddress())
+                        .address(ATLAS_REACT_ABRAHAMSSON.getAddress())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getAddress().getZipCode(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getAddress().getZipCode(),
             certificate.certificateMetaData().getPatient().getAddress().getZipCode());
       }
 
@@ -224,13 +224,13 @@ class CertificateTest {
             actionEvaluationBuilder
                 .patient(
                     athenaReactAnderssonBuilder()
-                        .address(ALVE_REACT_ALFREDSSON.getAddress())
+                        .address(ATLAS_REACT_ABRAHAMSSON.getAddress())
                         .build()
                 )
                 .build()
         );
 
-        assertEquals(ALVE_REACT_ALFREDSSON.getAddress().getStreet(),
+        assertEquals(ATLAS_REACT_ABRAHAMSSON.getAddress().getStreet(),
             certificate.certificateMetaData().getPatient().getAddress().getStreet());
       }
 

--- a/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataPatient.java
+++ b/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataPatient.java
@@ -10,6 +10,8 @@ public class TestDataPatient {
 
   public static final Patient ATHENA_REACT_ANDERSSON = athenaReactAnderssonBuilder().build();
   public static final Patient ALVE_REACT_ALFREDSSON = alveReactAlfredssonBuilder().build();
+  public static final Patient ATLAS_REACT_ABRAHAMSSON = atlasReactAbrahamssonBuilder().build();
+  public static final Patient ANONYMA_REACT_ATTILA = anonymaReactAttilaBuilder().build();
 
   public static Patient.PatientBuilder athenaReactAnderssonBuilder() {
     return Patient.builder()
@@ -63,5 +65,59 @@ public class TestDataPatient {
         .testIndicated(TestDataPatientConstants.ALVE_REACT_ALFREDSSON_TEST_INDICATED)
         .deceased(TestDataPatientConstants.ALVE_REACT_ALFREDSSON_DECEASED)
         .protectedPerson(TestDataPatientConstants.ALVE_REACT_ALFREDSSON_PROTECTED_PERSON);
+  }
+
+  public static Patient.PatientBuilder atlasReactAbrahamssonBuilder() {
+    return Patient.builder()
+        .id(
+            PersonId.builder()
+                .id(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_ID)
+                .type(PersonIdType.PERSONAL_IDENTITY_NUMBER)
+                .build()
+        )
+        .name(
+            Name.builder()
+                .firstName(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_FIRST_NAME)
+                .middleName(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_MIDDLE_NAME)
+                .lastName(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_LAST_NAME)
+                .build()
+        )
+        .address(
+            PersonAddress.builder()
+                .street(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_STREET)
+                .city(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_CITY)
+                .zipCode(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_ZIP_CODE)
+                .build()
+        )
+        .testIndicated(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_TEST_INDICATED)
+        .deceased(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_DECEASED)
+        .protectedPerson(TestDataPatientConstants.ATLAS_REACT_ABRAHAMSSON_PROTECTED_PERSON);
+  }
+
+  public static Patient.PatientBuilder anonymaReactAttilaBuilder() {
+    return Patient.builder()
+        .id(
+            PersonId.builder()
+                .id(TestDataPatientConstants.ANONYMA_REACT_ATTILA_ID)
+                .type(PersonIdType.PERSONAL_IDENTITY_NUMBER)
+                .build()
+        )
+        .name(
+            Name.builder()
+                .firstName(TestDataPatientConstants.ANONYMA_REACT_ATTILA_FIRST_NAME)
+                .middleName(TestDataPatientConstants.ANONYMA_REACT_ATTILA_MIDDLE_NAME)
+                .lastName(TestDataPatientConstants.ANONYMA_REACT_ATTILA_LAST_NAME)
+                .build()
+        )
+        .address(
+            PersonAddress.builder()
+                .street(TestDataPatientConstants.ANONYMA_REACT_ATTILA_STREET)
+                .city(TestDataPatientConstants.ANONYMA_REACT_ATTILA_CITY)
+                .zipCode(TestDataPatientConstants.ANONYMA_REACT_ATTILA_ZIP_CODE)
+                .build()
+        )
+        .testIndicated(TestDataPatientConstants.ANONYMA_REACT_ATTILA_TEST_INDICATED)
+        .deceased(TestDataPatientConstants.ANONYMA_REACT_ATTILA_DECEASED)
+        .protectedPerson(TestDataPatientConstants.ANONYMA_REACT_ATTILA_PROTECTED_PERSON);
   }
 }

--- a/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataPatientConstants.java
+++ b/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataPatientConstants.java
@@ -6,6 +6,7 @@ import se.inera.intyg.certificateservice.domain.patient.model.TestIndicated;
 
 public class TestDataPatientConstants {
 
+  private static final String EMPTY = "";
   public static final TestIndicated TEST_INDICATED_TRUE = new TestIndicated(true);
   public static final TestIndicated TEST_INDICATED_FALSE = new TestIndicated(false);
   public static final Deceased DECEASED_TRUE = new Deceased(true);
@@ -42,7 +43,38 @@ public class TestDataPatientConstants {
   public static final String ALVE_REACT_ALFREDSSON_CITY = "Karlstad";
   public static final String ALVE_REACT_ALFREDSSON_ZIP_CODE = "65340";
   public static final TestIndicated ALVE_REACT_ALFREDSSON_TEST_INDICATED = TEST_INDICATED_FALSE;
-  public static final Deceased ALVE_REACT_ALFREDSSON_DECEASED = DECEASED_TRUE;
+  public static final Deceased ALVE_REACT_ALFREDSSON_DECEASED = DECEASED_FALSE;
   public static final ProtectedPerson ALVE_REACT_ALFREDSSON_PROTECTED_PERSON = PROTECTED_PERSON_FALSE;
 
+  public static final String ATLAS_REACT_ABRAHAMSSON_ID = "19411129-9055";
+  public static final String ATLAS_REACT_ABRAHAMSSON_FIRST_NAME = "Atlas";
+  public static final String ATLAS_REACT_ABRAHAMSSON_MIDDLE_NAME = "React";
+  public static final String ATLAS_REACT_ABRAHAMSSON_LAST_NAME = "Abrahamsson";
+  public static final String ATLAS_REACT_ABRAHAMSSON_FULL_NAME = "%s %s %s".formatted(
+      ATLAS_REACT_ABRAHAMSSON_FIRST_NAME,
+      ATLAS_REACT_ABRAHAMSSON_MIDDLE_NAME,
+      ATLAS_REACT_ABRAHAMSSON_LAST_NAME
+  );
+  public static final String ATLAS_REACT_ABRAHAMSSON_STREET = "Avlidengatan 456";
+  public static final String ATLAS_REACT_ABRAHAMSSON_CITY = "Karlstad";
+  public static final String ATLAS_REACT_ABRAHAMSSON_ZIP_CODE = "65340";
+  public static final TestIndicated ATLAS_REACT_ABRAHAMSSON_TEST_INDICATED = TEST_INDICATED_FALSE;
+  public static final Deceased ATLAS_REACT_ABRAHAMSSON_DECEASED = DECEASED_TRUE;
+  public static final ProtectedPerson ATLAS_REACT_ABRAHAMSSON_PROTECTED_PERSON = PROTECTED_PERSON_FALSE;
+
+  public static final String ANONYMA_REACT_ATTILA_ID = "19401201-9149";
+  public static final String ANONYMA_REACT_ATTILA_FIRST_NAME = "Atlas";
+  public static final String ANONYMA_REACT_ATTILA_MIDDLE_NAME = "React";
+  public static final String ANONYMA_REACT_ATTILA_LAST_NAME = "Abrahamsson";
+  public static final String ANONYMA_REACT_ATTILA_FULL_NAME = "%s %s %s".formatted(
+      ANONYMA_REACT_ATTILA_FIRST_NAME,
+      ANONYMA_REACT_ATTILA_MIDDLE_NAME,
+      ANONYMA_REACT_ATTILA_LAST_NAME
+  );
+  public static final String ANONYMA_REACT_ATTILA_STREET = EMPTY;
+  public static final String ANONYMA_REACT_ATTILA_CITY = EMPTY;
+  public static final String ANONYMA_REACT_ATTILA_ZIP_CODE = EMPTY;
+  public static final TestIndicated ANONYMA_REACT_ATTILA_TEST_INDICATED = TEST_INDICATED_FALSE;
+  public static final Deceased ANONYMA_REACT_ATTILA_DECEASED = DECEASED_FALSE;
+  public static final ProtectedPerson ANONYMA_REACT_ATTILA_PROTECTED_PERSON = PROTECTED_PERSON_TRUE;
 }

--- a/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataUser.java
+++ b/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataUser.java
@@ -4,6 +4,10 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserCons
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.AJLA_DOCTOR_HSA_ID;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.AJLA_DOCTOR_NAME;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.AJLA_DOCTOR_ROLE;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_BLOCKED;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_HSA_ID;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_NAME;
+import static se.inera.intyg.certificateservice.domain.testdata.TestDataUserConstants.ALVA_VARDADMINISTRATOR_ROLE;
 
 import se.inera.intyg.certificateservice.domain.certificate.model.HsaId;
 import se.inera.intyg.certificateservice.domain.patient.model.Name;
@@ -13,6 +17,7 @@ import se.inera.intyg.certificateservice.domain.user.model.User.UserBuilder;
 public class TestDataUser {
 
   public static final User AJLA_DOKTOR = ajlaDoctorBuilder().build();
+  public static final User ALVA_VARDADMINISTRATOR = alvaVardadministratorBuilder().build();
 
   public static UserBuilder ajlaDoctorBuilder() {
     return User.builder()
@@ -24,5 +29,17 @@ public class TestDataUser {
         )
         .blocked(AJLA_DOCTOR_BLOCKED)
         .role(AJLA_DOCTOR_ROLE);
+  }
+
+  public static UserBuilder alvaVardadministratorBuilder() {
+    return User.builder()
+        .hsaId(new HsaId(ALVA_VARDADMINISTRATOR_HSA_ID))
+        .name(
+            Name.builder()
+                .lastName(ALVA_VARDADMINISTRATOR_NAME)
+                .build()
+        )
+        .blocked(ALVA_VARDADMINISTRATOR_BLOCKED)
+        .role(ALVA_VARDADMINISTRATOR_ROLE);
   }
 }

--- a/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/CertificateTypeInfoRequestBuilder.java
+++ b/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/CertificateTypeInfoRequestBuilder.java
@@ -1,17 +1,21 @@
 package se.inera.intyg.certificateservice.integrationtest.util;
 
-import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.athenaReactAnderssonDtoBuilder;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.ATHENA_REACT_ANDERSSON_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_ALLERGIMOTTAGNINGEN_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_MEDICINCENTRUM_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_REGIONEN_DTO;
-import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO.ajlaDoktorDtoBuilder;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO.AJLA_DOCTOR_DTO;
 
 import se.inera.intyg.certificateservice.application.certificatetypeinfo.dto.GetCertificateTypeInfoRequest;
+import se.inera.intyg.certificateservice.application.common.dto.PatientDTO;
+import se.inera.intyg.certificateservice.application.common.dto.UnitDTO;
+import se.inera.intyg.certificateservice.application.common.dto.UserDTO;
 
 public class CertificateTypeInfoRequestBuilder {
 
-  private boolean blocked = false;
-  private boolean deceased = false;
+  private UnitDTO unit = ALFA_ALLERGIMOTTAGNINGEN_DTO;
+  private UserDTO user = AJLA_DOCTOR_DTO;
+  private PatientDTO patient = ATHENA_REACT_ANDERSSON_DTO;
 
   public static CertificateTypeInfoRequestBuilder create() {
     return new CertificateTypeInfoRequestBuilder();
@@ -21,30 +25,27 @@ public class CertificateTypeInfoRequestBuilder {
 
   }
 
-  public CertificateTypeInfoRequestBuilder blocked(boolean blocked) {
-    this.blocked = blocked;
+  public CertificateTypeInfoRequestBuilder user(UserDTO user) {
+    this.user = user;
     return this;
   }
 
-  public CertificateTypeInfoRequestBuilder deceased(boolean deceased) {
-    this.deceased = deceased;
+  public CertificateTypeInfoRequestBuilder unit(UnitDTO unit) {
+    this.unit = unit;
+    return this;
+  }
+
+  public CertificateTypeInfoRequestBuilder patient(PatientDTO patient) {
+    this.patient = patient;
     return this;
   }
 
   public GetCertificateTypeInfoRequest build() {
     return GetCertificateTypeInfoRequest.builder()
-        .user(
-            ajlaDoktorDtoBuilder()
-                .blocked(blocked)
-                .build()
-        )
-        .patient(
-            athenaReactAnderssonDtoBuilder()
-                .deceased(deceased)
-                .build()
-        )
+        .user(user)
+        .patient(patient)
         .careProvider(ALFA_REGIONEN_DTO)
-        .unit(ALFA_ALLERGIMOTTAGNINGEN_DTO)
+        .unit(unit)
         .careUnit(ALFA_MEDICINCENTRUM_DTO)
         .build();
   }

--- a/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/CreateCertificateRequestBuilder.java
+++ b/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/CreateCertificateRequestBuilder.java
@@ -1,22 +1,26 @@
 package se.inera.intyg.certificateservice.integrationtest.util;
 
-import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.athenaReactAnderssonDtoBuilder;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonPatientDTO.ATHENA_REACT_ANDERSSON_DTO;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_ALLERGIMOTTAGNINGEN_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_MEDICINCENTRUM_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_REGIONEN_DTO;
-import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.alfaAllergimottagningenDtoBuilder;
-import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO.ajlaDoktorDtoBuilder;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO.AJLA_DOCTOR_DTO;
 
 import se.inera.intyg.certificateservice.application.certificate.dto.CreateCertificateRequest;
 import se.inera.intyg.certificateservice.application.certificatetypeinfo.dto.CertificateModelIdDTO;
+import se.inera.intyg.certificateservice.application.common.dto.PatientDTO;
+import se.inera.intyg.certificateservice.application.common.dto.UnitDTO;
+import se.inera.intyg.certificateservice.application.common.dto.UserDTO;
 
 public class CreateCertificateRequestBuilder {
 
   private static final String VERSION = "1.0";
   private static final String TYPE = "fk7211";
 
-  private boolean blocked = false;
-  private boolean deceased = false;
-  private boolean inactive = false;
+  private UnitDTO unit = ALFA_ALLERGIMOTTAGNINGEN_DTO;
+  private UserDTO user = AJLA_DOCTOR_DTO;
+  private PatientDTO patient = ATHENA_REACT_ANDERSSON_DTO;
+
   private CertificateModelIdDTO certificateModelId = CertificateModelIdDTO.builder()
       .version(VERSION)
       .type(TYPE)
@@ -30,18 +34,18 @@ public class CreateCertificateRequestBuilder {
 
   }
 
-  public CreateCertificateRequestBuilder blocked(boolean blocked) {
-    this.blocked = blocked;
+  public CreateCertificateRequestBuilder user(UserDTO user) {
+    this.user = user;
     return this;
   }
 
-  public CreateCertificateRequestBuilder deceased(boolean deceased) {
-    this.deceased = deceased;
+  public CreateCertificateRequestBuilder unit(UnitDTO unit) {
+    this.unit = unit;
     return this;
   }
 
-  public CreateCertificateRequestBuilder inactive(boolean inactive) {
-    this.inactive = inactive;
+  public CreateCertificateRequestBuilder patient(PatientDTO patient) {
+    this.patient = patient;
     return this;
   }
 
@@ -53,22 +57,10 @@ public class CreateCertificateRequestBuilder {
 
   public CreateCertificateRequest build() {
     return CreateCertificateRequest.builder()
-        .user(
-            ajlaDoktorDtoBuilder()
-                .blocked(blocked)
-                .build()
-        )
-        .patient(
-            athenaReactAnderssonDtoBuilder()
-                .deceased(deceased)
-                .build()
-        )
+        .user(user)
+        .patient(patient)
         .careProvider(ALFA_REGIONEN_DTO)
-        .unit(
-            alfaAllergimottagningenDtoBuilder()
-                .inactive(inactive)
-                .build()
-        )
+        .unit(unit)
         .careUnit(ALFA_MEDICINCENTRUM_DTO)
         .certificateModelId(
             certificateModelId

--- a/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/GetCertificateRequestBuilder.java
+++ b/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/GetCertificateRequestBuilder.java
@@ -3,15 +3,17 @@ package se.inera.intyg.certificateservice.integrationtest.util;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_ALLERGIMOTTAGNINGEN_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_MEDICINCENTRUM_DTO;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUnitDTO.ALFA_REGIONEN_DTO;
+import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO.AJLA_DOCTOR_DTO;
 
 import se.inera.intyg.certificateservice.application.certificate.dto.GetCertificateRequest;
 import se.inera.intyg.certificateservice.application.common.dto.UnitDTO;
-import se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO;
+import se.inera.intyg.certificateservice.application.common.dto.UserDTO;
 
 public class GetCertificateRequestBuilder {
 
   private UnitDTO unit = ALFA_ALLERGIMOTTAGNINGEN_DTO;
   private UnitDTO careUnit = ALFA_MEDICINCENTRUM_DTO;
+  private UserDTO user = AJLA_DOCTOR_DTO;
 
   public static GetCertificateRequestBuilder create() {
     return new GetCertificateRequestBuilder();
@@ -31,9 +33,14 @@ public class GetCertificateRequestBuilder {
     return this;
   }
 
+  public GetCertificateRequestBuilder user(UserDTO user) {
+    this.user = user;
+    return this;
+  }
+
   public GetCertificateRequest build() {
     return GetCertificateRequest.builder()
-        .user(TestDataCommonUserDTO.AJLA_DOCTOR_DTO)
+        .user(user)
         .careProvider(ALFA_REGIONEN_DTO)
         .unit(unit)
         .careUnit(careUnit)

--- a/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/TestabilityCertificateRequestBuilder.java
+++ b/certificate-service/integration-test/src/test/java/se/inera/intyg/certificateservice/integrationtest/util/TestabilityCertificateRequestBuilder.java
@@ -7,7 +7,9 @@ import static se.inera.intyg.certificateservice.application.testdata.TestDataCom
 import static se.inera.intyg.certificateservice.application.testdata.TestDataCommonUserDTO.AJLA_DOCTOR_DTO;
 
 import se.inera.intyg.certificateservice.application.certificatetypeinfo.dto.CertificateModelIdDTO;
+import se.inera.intyg.certificateservice.application.common.dto.PatientDTO;
 import se.inera.intyg.certificateservice.application.common.dto.UnitDTO;
+import se.inera.intyg.certificateservice.application.common.dto.UserDTO;
 import se.inera.intyg.certificateservice.testability.certificate.dto.TestabilityCertificateRequest;
 
 public class TestabilityCertificateRequestBuilder {
@@ -21,6 +23,8 @@ public class TestabilityCertificateRequestBuilder {
       .build();
 
   private UnitDTO unit = ALFA_ALLERGIMOTTAGNINGEN_DTO;
+  private UserDTO user = AJLA_DOCTOR_DTO;
+  private PatientDTO patient = ATHENA_REACT_ANDERSSON_DTO;
 
   public static TestabilityCertificateRequestBuilder create() {
     return new TestabilityCertificateRequestBuilder();
@@ -30,8 +34,18 @@ public class TestabilityCertificateRequestBuilder {
 
   }
 
+  public TestabilityCertificateRequestBuilder user(UserDTO user) {
+    this.user = user;
+    return this;
+  }
+
   public TestabilityCertificateRequestBuilder unit(UnitDTO unit) {
     this.unit = unit;
+    return this;
+  }
+
+  public TestabilityCertificateRequestBuilder patient(PatientDTO patient) {
+    this.patient = patient;
     return this;
   }
 
@@ -43,8 +57,8 @@ public class TestabilityCertificateRequestBuilder {
 
   public TestabilityCertificateRequest build() {
     return TestabilityCertificateRequest.builder()
-        .user(AJLA_DOCTOR_DTO)
-        .patient(ATHENA_REACT_ANDERSSON_DTO)
+        .user(user)
+        .patient(patient)
         .careProvider(ALFA_REGIONEN_DTO)
         .unit(unit)
         .careUnit(ALFA_MEDICINCENTRUM_DTO)


### PR DESCRIPTION
Added some testdata and also fixed a mistake with using Alve instead of Atlas (deceased).