### PR TITLE
K1J-230: Update spring boot bom and apache cxf for intyg-proxy-service (resolve vulnerabilities for apache cxf)

### DIFF
--- a/intyg-proxy-service/app/build.gradle
+++ b/intyg-proxy-service/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.8'
+    id 'org.springframework.boot' version '3.2.9'
 }
 
 dependencies {

--- a/intyg-proxy-service/build.gradle
+++ b/intyg-proxy-service/build.gradle
@@ -6,14 +6,14 @@ plugins {
 }
 
 ext {
-    cxfVersion = "4.0.0"
+    cxfVersion = "4.0.5"
     cxfPluginVersion = "4.0.0"
     jaxb2Version = "3.0.0"
     jaxb2NamespacePrefixVersion = "2.0"
     jaxbImplVersion = "4.0.1"
     jaxsWsVersion = "4.0.1"
     jakartaWsVersion = "4.0.0"
-    springbootMavenBomVersion = '3.2.8'
+    springbootMavenBomVersion = '3.2.9'
     guavaVersion = '33.0.0-jre'
 
     ineraMavenRepository = 'https://nexus.drift.inera.se/repository/it-public/'

--- a/intyg-proxy-service/build.gradle
+++ b/intyg-proxy-service/build.gradle
@@ -1,16 +1,16 @@
 plugins {
-    id 'org.springframework.boot' version '3.2.8'
+    id 'org.springframework.boot' version '3.2.9'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.sonarqube' version '4.4.1.3373'
     id "org.owasp.dependencycheck" version "10.0.4"
 }
 
 ext {
-    cxfVersion = "4.0.5"
+    cxfVersion = "4.0.2"
     cxfPluginVersion = "4.0.0"
     jaxb2Version = "3.0.0"
     jaxb2NamespacePrefixVersion = "2.0"
-    jaxbImplVersion = "4.0.1"
+    jaxbImplVersion = "4.0.2"
     jaxsWsVersion = "4.0.1"
     jakartaWsVersion = "4.0.0"
     springbootMavenBomVersion = '3.2.9'
@@ -44,7 +44,7 @@ dependencyCheck {
     formats = List.of("HTML", "JSON")
 
     nvd {
-        datafeedUrl="${nvdMirror}"
+        datafeedUrl = "${nvdMirror}"
     }
 }
 


### PR DESCRIPTION
* When updating to apacheCxf 4.0.5 (which has resolved the vulnerabilities) there is an exception when generating java-code from the wsdl with wsdl2java. This has to be resolved before this PR can be ready.

An analysis of the vulnerabilities has shown that it is mainly for using Apache CXF for Rest-API:s. This is not applicable to intyg-proxy-service as it is only used for consuming SOAP Webservices.