### PR TITLE
K1J-1244: Schematron fix

### DIFF
--- a/certificate-service/app/src/main/resources/fk7804/schematron/lisjp.v2.sch
+++ b/certificate-service/app/src/main/resources/fk7804/schematron/lisjp.v2.sch
@@ -260,14 +260,6 @@
     </iso:rule>
   </iso:pattern>
 
-  <iso:pattern id="q29">
-    <iso:rule context="//gn:svar[@id='29']">
-      <iso:assert test="count(gn:delsvar[@id='29.1']) = 1">'Nuvarande arbete' måste ha ett
-        textdelsvar.
-      </iso:assert>
-    </iso:rule>
-  </iso:pattern>
-
   <iso:pattern id="q32">
     <iso:rule context="//gn:svar[@id='32']">
       <iso:assert test="count(gn:delsvar[@id='32.1']) = 1">'Nedsättning av arbetsförmågan' måste ha


### PR DESCRIPTION
- Q27-Q29 are used multiple times in file. 
- Those are redundant, there are already assersions present, that are more complete and covers the same assertion.