### PR TITLE
K1J-1418: Handle validation of accepted message types for incoming administrative messages

### DIFF
--- a/certificate-service/app/src/main/java/se/inera/intyg/certificateservice/application/message/service/IncomingMessageService.java
+++ b/certificate-service/app/src/main/java/se/inera/intyg/certificateservice/application/message/service/IncomingMessageService.java
@@ -35,7 +35,7 @@ public class IncomingMessageService {
           new MessageId(incomingMessageRequest.getReminderMessageId()),
           messageConverter.convertReminder(incomingMessageRequest)
       );
-      case KONTKT, OVRIGT -> {
+      default -> {
         if (isAnswer(incomingMessageRequest)) {
           receiveAnswerMessageDomainService.receive(
               new MessageId(incomingMessageRequest.getAnswerMessageId()),
@@ -47,9 +47,6 @@ public class IncomingMessageService {
           );
         }
       }
-      default -> throw new IllegalArgumentException(
-          "Message type '%s' is not supported!".formatted(incomingMessageRequest.getType())
-      );
     }
   }
 

--- a/certificate-service/app/src/test/java/se/inera/intyg/certificateservice/application/message/service/IncomingMessageServiceTest.java
+++ b/certificate-service/app/src/test/java/se/inera/intyg/certificateservice/application/message/service/IncomingMessageServiceTest.java
@@ -8,7 +8,6 @@ import static se.inera.intyg.certificateservice.application.testdata.TestDataInc
 import static se.inera.intyg.certificateservice.application.testdata.TestDataIncomingMessage.INCOMING_COMPLEMENT_MESSAGE;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataIncomingMessage.INCOMING_QUESTION_MESSAGE;
 import static se.inera.intyg.certificateservice.application.testdata.TestDataIncomingMessage.INCOMING_REMINDER_MESSAGE;
-import static se.inera.intyg.certificateservice.application.testdata.TestDataIncomingMessage.incomingComplementMessageBuilder;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataMessage.ANSWER;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataMessage.COMPLEMENT_MESSAGE;
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataMessage.CONTACT_MESSAGE;
@@ -21,7 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.inera.intyg.certificateservice.application.message.dto.IncomingMessageRequest;
-import se.inera.intyg.certificateservice.application.message.dto.MessageTypeDTO;
 import se.inera.intyg.certificateservice.application.message.service.converter.MessageConverter;
 import se.inera.intyg.certificateservice.application.message.service.validator.IncomingMessageValidator;
 import se.inera.intyg.certificateservice.domain.message.model.MessageId;
@@ -92,16 +90,5 @@ class IncomingMessageServiceTest {
         .convert(INCOMING_QUESTION_MESSAGE);
     incomingMessageService.receive(INCOMING_QUESTION_MESSAGE);
     verify(receiveQuestionMessageDomainService).receive(CONTACT_MESSAGE);
-  }
-
-  @Test
-  void shallThrowExceptionIfMessageTypeIsNotHandled() {
-    final var notHandledMessage = incomingComplementMessageBuilder()
-        .type(MessageTypeDTO.AVSTMN)
-        .build();
-
-    assertThrows(IllegalArgumentException.class,
-        () -> incomingMessageService.receive(notHandledMessage)
-    );
   }
 }

--- a/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/message/service/ReceiveQuestionMessageDomainService.java
+++ b/certificate-service/domain/src/main/java/se/inera/intyg/certificateservice/domain/message/service/ReceiveQuestionMessageDomainService.java
@@ -33,6 +33,19 @@ public class ReceiveQuestionMessageDomainService {
       );
     }
 
+    final var isAllowedMessageType = certificate.certificateModel().messageTypes().stream()
+        .anyMatch(type -> type.type().equals(message.type()));
+    if (!isAllowedMessageType) {
+      throw new CertificateActionForbidden(
+          "Not allowed to receive message of type %s on certificate for %s"
+              .formatted(message.type(), certificate.id().id()),
+          List.of(
+              "Message type %s not allowed on certificate model %s"
+                  .formatted(message.type(), certificate.certificateModel().id())
+          )
+      );
+    }
+
     return messageRepository.save(message);
   }
 }

--- a/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataCertificateModel.java
+++ b/certificate-service/domain/src/testFixtures/java/se/inera/intyg/certificateservice/domain/testdata/TestDataCertificateModel.java
@@ -31,9 +31,13 @@ import static se.inera.intyg.certificateservice.domain.testdata.TestDataPdfSpeci
 import static se.inera.intyg.certificateservice.domain.testdata.TestDataPdfSpecification.FK7809_PDF_SPECIFICATION;
 
 import java.util.Collections;
+import java.util.List;
 import se.inera.intyg.certificateservice.domain.action.certificate.model.CertificateActionFactory;
+import se.inera.intyg.certificateservice.domain.certificatemodel.model.CertificateMessageType;
 import se.inera.intyg.certificateservice.domain.certificatemodel.model.CertificateModel;
 import se.inera.intyg.certificateservice.domain.certificatemodel.model.CertificateModelId;
+import se.inera.intyg.certificateservice.domain.message.model.MessageType;
+import se.inera.intyg.certificateservice.domain.message.model.Subject;
 
 public class TestDataCertificateModel {
 
@@ -188,7 +192,15 @@ public class TestDataCertificateModel {
         .availableForCitizen(true)
         .schematronPath(TestDataCertificateModelConstants.FK7810_SCHEMATRON_PATH)
         .recipient(TestDataCertificateModelConstants.FK_RECIPIENT)
-        .certificateActionFactory(new CertificateActionFactory(null));
+        .certificateActionFactory(new CertificateActionFactory(null))
+        .messageTypes(
+            List.of(
+                CertificateMessageType.builder()
+                    .type(MessageType.CONTACT)
+                    .subject(new Subject(MessageType.CONTACT.displayName()))
+                    .build()
+            )
+        );
   }
 
   public static CertificateModel.CertificateModelBuilder fk7804certificateModelBuilder() {


### PR DESCRIPTION
This is a fix of a bug identified when testing FK7804 v2. 

The problem was that AVSTMN messages wasn't accepted even if the model was configured for it.

Refactored to let RecieveQuestionMessageDomainService to validate the type instead of it being validated in the app service IncomingMessageService. This to remove the dependency to domain logic in the app-layer.