### PR TITLE
K1J-1432: Handle messages with relation and recipient

### DIFF
--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/PseudonymizedAnalyticsMessage.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/PseudonymizedAnalyticsMessage.java
@@ -25,5 +25,9 @@ public class PseudonymizedAnalyticsMessage {
   String certificatePatientId;
   String certificateUnitId;
   String certificateCareProviderId;
+  String certificateRelationParentId;
+  String certificateRelationParentType;
+
+  String recipientId;
 
 }

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventCertificateRelationV1.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventCertificateRelationV1.java
@@ -1,0 +1,22 @@
+package se.inera.intyg.certificateanalyticsservice.application.messages.model.v1;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Value;
+import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateRelationV1.CertificateAnalyticsEventCertificateRelationV1Builder;
+
+@Value
+@Builder
+@JsonDeserialize(builder = CertificateAnalyticsEventCertificateRelationV1Builder.class)
+public class CertificateAnalyticsEventCertificateRelationV1 implements Serializable {
+
+  String id;
+  String type;
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class CertificateAnalyticsEventCertificateRelationV1Builder {
+
+  }
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventCertificateV1.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventCertificateV1.java
@@ -19,6 +19,8 @@ public class CertificateAnalyticsEventCertificateV1 implements Serializable {
   String unitId;
   String careProviderId;
 
+  CertificateAnalyticsEventCertificateRelationV1 parent;
+
   @JsonPOJOBuilder(withPrefix = "")
   public static class CertificateAnalyticsEventCertificateV1Builder {
 

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventMessageV1.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventMessageV1.java
@@ -18,6 +18,7 @@ public class CertificateAnalyticsEventMessageV1 implements CertificateAnalyticsM
 
   CertificateAnalyticsEventCertificateV1 certificate;
   CertificateAnalyticsEventV1 event;
+  CertificateAnalyticsEventRecipientV1 recipient;
 
   @JsonPOJOBuilder(withPrefix = "")
   public static class CertificateAnalyticsEventMessageV1Builder {

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventRecipientV1.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventRecipientV1.java
@@ -1,0 +1,21 @@
+package se.inera.intyg.certificateanalyticsservice.application.messages.model.v1;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.io.Serializable;
+import lombok.Builder;
+import lombok.Value;
+import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventRecipientV1.CertificateAnalyticsEventRecipientV1Builder;
+
+@Value
+@Builder
+@JsonDeserialize(builder = CertificateAnalyticsEventRecipientV1Builder.class)
+public class CertificateAnalyticsEventRecipientV1 implements Serializable {
+
+  String id;
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class CertificateAnalyticsEventRecipientV1Builder {
+
+  }
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventV1Pseudonymizer.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventV1Pseudonymizer.java
@@ -60,6 +60,28 @@ public class CertificateAnalyticsEventV1Pseudonymizer implements AnalyticsMessag
         )
         .certificateUnitId(messageV1.getCertificate().getUnitId())
         .certificateCareProviderId(messageV1.getCertificate().getCareProviderId())
+        .certificateRelationParentId(
+            missingParent(messageV1.getCertificate()) ? null :
+                pseudonymizationTokenGenerator.parentCertificateId(
+                    messageV1.getCertificate().getParent().getId()
+                )
+        )
+        .certificateRelationParentType(
+            missingParent(messageV1.getCertificate()) ? null :
+                messageV1.getCertificate().getParent().getType()
+        )
+        .recipientId(
+            missingRecipient(messageV1) ? null :
+                messageV1.getRecipient().getId()
+        )
         .build();
+  }
+
+  private boolean missingParent(CertificateAnalyticsEventCertificateV1 certificate) {
+    return certificate.getParent() == null || certificate.getParent().getId() == null;
+  }
+
+  private boolean missingRecipient(CertificateAnalyticsEventMessageV1 message) {
+    return message.getRecipient() == null || message.getRecipient().getId() == null;
   }
 }

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/CertificateRelationEntity.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/CertificateRelationEntity.java
@@ -24,7 +24,7 @@ public class CertificateRelationEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "key")
+  @Column(name = "`key`")
   private Long key;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/CertificateRelationEntity.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/CertificateRelationEntity.java
@@ -1,0 +1,41 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "certificate_relation")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CertificateRelationEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "key")
+  private Long key;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "parent_certificate_key", referencedColumnName = "key", nullable = false)
+  private CertificateEntity parentCertificate;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "child_certificate_key", referencedColumnName = "key", nullable = false)
+  private CertificateEntity childCertificate;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "certificate_relation_type_key", referencedColumnName = "key", nullable = false)
+  private CertificateRelationTypeEntity relationType;
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/CertificateRelationTypeEntity.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/CertificateRelationTypeEntity.java
@@ -1,0 +1,29 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "certificate_relation_type")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CertificateRelationTypeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "key")
+  private Long key;
+
+  @Column(name = "relation_type", nullable = false, unique = true, length = 64)
+  private String relationType;
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/EventEntity.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/EventEntity.java
@@ -62,6 +62,10 @@ public class EventEntity {
   @JoinColumn(name = "role_key", referencedColumnName = "key")
   private RoleEntity role;
 
+  @ManyToOne
+  @JoinColumn(name = "recipient_key", referencedColumnName = "key")
+  private RecipientEntity recipient;
+
   @Column(name = "message_id", unique = true, nullable = false, length = 22)
   private String messageId;
 }

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/RecipientEntity.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/RecipientEntity.java
@@ -1,0 +1,29 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "recipient")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecipientEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "`key`")
+  private Long key;
+
+  @Column(name = "recipient", nullable = false, length = 32)
+  private String recipient;
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/CertificateEntityMapper.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/CertificateEntityMapper.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.PseudonymizedAnalyticsMessage;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CareProviderRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateEntityRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateRelationEntityRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateRelationTypeEntityRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateTypeRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.PatientRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.UnitRepository;
@@ -19,20 +23,63 @@ public class CertificateEntityMapper {
   private final PatientRepository patientRepository;
   private final CertificateEntityRepository certificateEntityRepository;
   private final CertificateTypeRepository certificateTypeRepository;
+  private final CertificateRelationEntityRepository certificateRelationEntityRepository;
+  private final CertificateRelationTypeEntityRepository certificateRelationTypeEntityRepository;
 
   public CertificateEntity map(PseudonymizedAnalyticsMessage message) {
-    return certificateEntityRepository.findByCertificateId(message.getCertificateId())
-        .orElseGet(() -> certificateEntityRepository.save(CertificateEntity.builder()
-            .certificateId(message.getCertificateId())
-            .certificateType(
-                certificateTypeRepository.findOrCreate(
-                    message.getCertificateType(), message.getCertificateTypeVersion())
+    final var certificateEntity = certificateEntityRepository.findByCertificateId(
+            message.getCertificateId())
+        .orElseGet(() ->
+            certificateEntityRepository.save(CertificateEntity.builder()
+                .certificateId(message.getCertificateId())
+                .certificateType(
+                    certificateTypeRepository.findOrCreate(
+                        message.getCertificateType(), message.getCertificateTypeVersion()
+                    )
+                )
+                .patient(patientRepository.findOrCreate(message.getCertificatePatientId()))
+                .unit(unitRepository.findOrCreate(message.getCertificateUnitId()))
+                .careProvider(
+                    careProviderRepository.findOrCreate(message.getCertificateCareProviderId())
+                )
+                .build()
             )
-            .patient(patientRepository.findOrCreate(message.getCertificatePatientId()))
-            .unit(unitRepository.findOrCreate(message.getCertificateUnitId()))
-            .careProvider(
-                careProviderRepository.findOrCreate(message.getCertificateCareProviderId()))
-            .build()
-        ));
+        );
+
+    if (message.getCertificateRelationParentId() != null
+        && message.getCertificateRelationParentType() != null) {
+      certificateEntityRepository.findByCertificateId(message.getCertificateRelationParentId())
+          .ifPresent(parent -> {
+                final var relationType = certificateRelationTypeEntityRepository
+                    .findByRelationType(message.getCertificateRelationParentType())
+                    .orElseGet(() ->
+                        certificateRelationTypeEntityRepository.save(
+                            CertificateRelationTypeEntity.builder()
+                                .relationType(message.getCertificateRelationParentType())
+                                .build()
+                        )
+                    );
+
+                final var exists = certificateRelationEntityRepository
+                    .findAll().stream()
+                    .anyMatch(rel ->
+                        rel.getParentCertificate().equals(parent)
+                            && rel.getChildCertificate().equals(certificateEntity)
+                            && rel.getRelationType().equals(relationType)
+                    );
+
+                if (!exists) {
+                  certificateRelationEntityRepository.save(
+                      CertificateRelationEntity.builder()
+                          .parentCertificate(parent)
+                          .childCertificate(certificateEntity)
+                          .relationType(relationType)
+                          .build()
+                  );
+                }
+              }
+          );
+    }
+    return certificateEntity;
   }
 }

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/EventMapper.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/EventMapper.java
@@ -7,6 +7,7 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.ent
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CareProviderRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.EventTypeRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.OriginRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.RecipientRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.RoleRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.SessionRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.UnitRepository;
@@ -24,6 +25,7 @@ public class EventMapper {
   private final EventTypeRepository eventTypeRepository;
   private final RoleRepository roleRepository;
   private final CertificateEntityMapper certificateEntityMapper;
+  private final RecipientRepository recipientRepository;
 
   public EventEntity toEntity(PseudonymizedAnalyticsMessage message) {
     final var certificateEntity = certificateEntityMapper.map(message);
@@ -37,6 +39,7 @@ public class EventMapper {
         .origin(originRepository.findOrCreate(message.getEventOrigin()))
         .eventType(eventTypeRepository.findOrCreate(message.getEventMessageType()))
         .role(roleRepository.findOrCreate(message.getEventRole()))
+        .recipient(recipientRepository.findOrCreate(message.getRecipientId()))
         .messageId(message.getMessageId())
         .build();
   }

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/RecipientEntityMapper.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/RecipientEntityMapper.java
@@ -1,0 +1,12 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.mapper;
+
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
+
+public class RecipientEntityMapper {
+
+  public static RecipientEntity map(String recipient) {
+    return RecipientEntity.builder()
+        .recipient(recipient)
+        .build();
+  }
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/CertificateRelationEntityRepository.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/CertificateRelationEntityRepository.java
@@ -1,0 +1,9 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationEntity;
+
+public interface CertificateRelationEntityRepository extends
+    JpaRepository<CertificateRelationEntity, Long> {
+
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/CertificateRelationTypeEntityRepository.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/CertificateRelationTypeEntityRepository.java
@@ -1,0 +1,11 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationTypeEntity;
+
+public interface CertificateRelationTypeEntityRepository extends
+    JpaRepository<CertificateRelationTypeEntity, Long> {
+
+  Optional<CertificateRelationTypeEntity> findByRelationType(String relationType);
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/JpaAnalyticsEventRepository.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/JpaAnalyticsEventRepository.java
@@ -2,6 +2,7 @@ package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.re
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.PseudonymizedAnalyticsMessage;
 import se.inera.intyg.certificateanalyticsservice.application.messages.repository.AnalyticsMessageRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.mapper.EventMapper;
@@ -19,6 +20,7 @@ public class JpaAnalyticsEventRepository implements AnalyticsMessageRepository {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public PseudonymizedAnalyticsMessage findByMessageId(String messageId) {
     return eventEntityRepository.findByMessageId(messageId)
         .map(eventMapper::toDomain)

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/RecipientEntityRepository.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/RecipientEntityRepository.java
@@ -1,0 +1,13 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
+
+@Repository
+public interface RecipientEntityRepository extends CrudRepository<RecipientEntity, Long> {
+
+  Optional<RecipientEntity> findByRecipient(String recipient);
+}
+

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/RecipientRepository.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/RecipientRepository.java
@@ -1,0 +1,21 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.mapper.RecipientEntityMapper;
+
+@Repository
+@RequiredArgsConstructor
+public class RecipientRepository {
+
+  private final RecipientEntityRepository recipientEntityRepository;
+
+  public RecipientEntity findOrCreate(String recipient) {
+    if (recipient == null || recipient.isBlank()) {
+      return null;
+    }
+    return recipientEntityRepository.findByRecipient(recipient)
+        .orElseGet(() -> recipientEntityRepository.save(RecipientEntityMapper.map(recipient)));
+  }
+}

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/pseudonymization/PseudonymizationTokenGenerator.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/infrastructure/pseudonymization/PseudonymizationTokenGenerator.java
@@ -55,6 +55,13 @@ public class PseudonymizationTokenGenerator {
     );
   }
 
+  public String parentCertificateId(String certificateId) {
+    return certificateId == null ? null : token(
+        FIELD_CERTIFICATE_ID,
+        normalize(certificateId)
+    );
+  }
+
   public String patientId(String patientId) {
     return patientId == null ? null : token(
         FIELD_PATIENT_ID,

--- a/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/testability/messages/TestabilityAnalyticsMessageRepository.java
+++ b/certificate-analytics-service/app/src/main/java/se/inera/intyg/certificateanalyticsservice/testability/messages/TestabilityAnalyticsMessageRepository.java
@@ -5,7 +5,9 @@ import static se.inera.intyg.certificateanalyticsservice.testability.configurati
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.mapper.EventMapper;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateRelationEntityRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.EventEntityRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.JpaAnalyticsEventRepository;
 
@@ -15,14 +17,20 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.rep
 public class TestabilityAnalyticsMessageRepository extends
     JpaAnalyticsEventRepository {
 
+  private final CertificateRelationEntityRepository certificateRelationEntityRepository;
+
   public TestabilityAnalyticsMessageRepository(
       EventEntityRepository eventEntityRepository,
-      EventMapper eventMapper) {
+      EventMapper eventMapper,
+      CertificateRelationEntityRepository certificateRelationEntityRepository) {
     super(eventEntityRepository, eventMapper);
+    this.certificateRelationEntityRepository = certificateRelationEntityRepository;
   }
 
   @Override
+  @Transactional
   public void clear() {
     getEventEntityRepository().deleteAll();
+    certificateRelationEntityRepository.deleteAll();
   }
 }

--- a/certificate-analytics-service/app/src/main/resources/changelog/db.changelog-master.xml
+++ b/certificate-analytics-service/app/src/main/resources/changelog/db.changelog-master.xml
@@ -79,9 +79,11 @@
         <constraints nullable="false"/>
       </column>
     </createTable>
+
     <addUniqueConstraint tableName="certificate_type"
       columnNames="certificate_type,certificate_type_version"
       constraintName="uk_certificate_type_type_version"/>
+
     <createTable tableName="patient">
       <column name="key" type="bigint unsigned auto_increment">
         <constraints primaryKey="true" nullable="false"/>
@@ -90,6 +92,7 @@
         <constraints nullable="false" unique="true"/>
       </column>
     </createTable>
+
     <createTable tableName="certificate">
       <column name="key" type="bigint unsigned auto_increment">
         <constraints primaryKey="true" nullable="false"/>
@@ -110,6 +113,7 @@
         <constraints nullable="false"/>
       </column>
     </createTable>
+
     <addForeignKeyConstraint baseTableName="certificate" baseColumnNames="certificate_type_key"
       referencedTableName="certificate_type" referencedColumnNames="key"
       constraintName="fk_certificate_certificate_type"/>
@@ -122,6 +126,16 @@
     <addForeignKeyConstraint baseTableName="certificate" baseColumnNames="patient_key"
       referencedTableName="patient" referencedColumnNames="key"
       constraintName="fk_certificate_patient"/>
+
+    <createTable tableName="recipient">
+      <column name="key" type="bigint unsigned auto_increment">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="recipient" type="varchar(32)">
+        <constraints nullable="false" unique="true"/>
+      </column>
+    </createTable>
+
     <createTable tableName="event">
       <column name="key" type="bigint unsigned auto_increment">
         <constraints primaryKey="true" nullable="false"/>
@@ -141,10 +155,12 @@
       <column name="session_key" type="bigint unsigned"/>
       <column name="unit_key" type="bigint unsigned"/>
       <column name="provider_key" type="bigint unsigned"/>
+      <column name="recipient_key" type="bigint unsigned"/>
       <column name="message_id" type="varchar(22)">
         <constraints nullable="false" unique="true"/>
       </column>
     </createTable>
+
     <addForeignKeyConstraint baseTableName="event" baseColumnNames="certificate_key"
       referencedTableName="certificate" referencedColumnNames="key"
       constraintName="fk_event_certificate"/>
@@ -169,6 +185,9 @@
     <addForeignKeyConstraint baseTableName="event" baseColumnNames="role_key"
       referencedTableName="role" referencedColumnNames="key"
       constraintName="fk_event_role"/>
+    <addForeignKeyConstraint baseTableName="event" baseColumnNames="recipient_key"
+      referencedTableName="recipient" referencedColumnNames="key"
+      constraintName="fk_event_recipient"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/certificate-analytics-service/app/src/main/resources/changelog/db.changelog-master.xml
+++ b/certificate-analytics-service/app/src/main/resources/changelog/db.changelog-master.xml
@@ -188,6 +188,47 @@
     <addForeignKeyConstraint baseTableName="event" baseColumnNames="recipient_key"
       referencedTableName="recipient" referencedColumnNames="key"
       constraintName="fk_event_recipient"/>
+
+    <createTable tableName="certificate_relation">
+      <column name="key" type="bigint unsigned auto_increment">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="parent_certificate_key" type="bigint unsigned">
+        <constraints nullable="false"/>
+      </column>
+      <column name="child_certificate_key" type="bigint unsigned">
+        <constraints nullable="false"/>
+      </column>
+      <column name="certificate_relation_type_key" type="bigint unsigned">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+
+    <createTable tableName="certificate_relation_type">
+      <column name="key" type="bigint unsigned auto_increment">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="relation_type" type="varchar(64)">
+        <constraints nullable="false" unique="true"/>
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint baseTableName="certificate_relation"
+      baseColumnNames="parent_certificate_key"
+      referencedTableName="certificate" referencedColumnNames="key"
+      constraintName="fk_certificate_relation_parent_certificate"/>
+    <addForeignKeyConstraint baseTableName="certificate_relation"
+      baseColumnNames="child_certificate_key"
+      referencedTableName="certificate" referencedColumnNames="key"
+      constraintName="fk_certificate_relation_child_certificate"/>
+    <addForeignKeyConstraint baseTableName="certificate_relation"
+      baseColumnNames="certificate_relation_type_key"
+      referencedTableName="certificate_relation_type" referencedColumnNames="key"
+      constraintName="fk_certificate_relation_type"/>
+
+    <addUniqueConstraint tableName="certificate_relation"
+      columnNames="parent_certificate_key,child_certificate_key"
+      constraintName="uk_certificate_relation_parent_child"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventV1ParserTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventV1ParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataMessages.draftMessageBuilder;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataMessages.replaceMessageBuilder;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataMessages.toJson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -46,7 +47,7 @@ class CertificateAnalyticsEventV1ParserTest {
 
   @Test
   void shallReturnParsedEvent() throws JsonProcessingException {
-    final var excepted = draftMessageBuilder().build();
+    final var excepted = replaceMessageBuilder().build();
     final var messageAsJson = toJson(excepted);
 
     when(objectMapper.readValue(messageAsJson, CertificateAnalyticsEventMessageV1.class))

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventV1PseudonymizerTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/application/messages/model/v1/CertificateAnalyticsEventV1PseudonymizerTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataMessages.draftMessageBuilder;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataMessages.replaceMessageBuilder;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataMessages.sentMessageBuilder;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -132,6 +134,30 @@ class CertificateAnalyticsEventV1PseudonymizerTest {
   }
 
   @Test
+  void shallReturnPseudonymizedCertificateRelationParentId() {
+    final var expected = "pseudonymized-certificate-id";
+    final var message = replaceMessageBuilder().build();
+
+    when(pseudonymizationTokenGenerator.parentCertificateId(
+        message.getCertificate().getParent().getId()))
+        .thenReturn(expected);
+
+    final var actual = certificateAnalyticsEventV1Pseudonymizer.pseudonymize(message);
+
+    assertEquals(expected, actual.getCertificateRelationParentId());
+  }
+
+  @Test
+  void shallReturnPseudonymizedCertificateRelationParentType() {
+    final var message = replaceMessageBuilder().build();
+    final var expected = message.getCertificate().getParent().getType();
+
+    final var actual = certificateAnalyticsEventV1Pseudonymizer.pseudonymize(message);
+
+    assertEquals(expected, actual.getCertificateRelationParentType());
+  }
+
+  @Test
   void shallReturnEventTimeStamp() {
     final var message = draftMessageBuilder().build();
     final var expected = message.getEvent().getTimestamp();
@@ -215,5 +241,15 @@ class CertificateAnalyticsEventV1PseudonymizerTest {
     final var actual = certificateAnalyticsEventV1Pseudonymizer.pseudonymize(message);
 
     assertEquals(expected, actual.getEventOrigin());
+  }
+
+  @Test
+  void shallReturnRecipient() {
+    final var message = sentMessageBuilder().build();
+    final var expected = message.getRecipient().getId();
+
+    final var actual = certificateAnalyticsEventV1Pseudonymizer.pseudonymize(message);
+
+    assertEquals(expected, actual.getRecipientId());
   }
 }

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/CertificateEntityMapperTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/CertificateEntityMapperTest.java
@@ -1,8 +1,14 @@
 package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_PARENT_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_PARENT_TYPE;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -12,11 +18,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CareProviderEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.PatientEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.UnitEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CareProviderRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateEntityRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateRelationEntityRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateRelationTypeEntityRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateTypeRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.PatientRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.UnitRepository;
@@ -37,6 +46,10 @@ class CertificateEntityMapperTest {
   private CertificateTypeRepository certificateTypeRepository;
   @Mock
   private CertificateEntityRepository certificateEntityRepository;
+  @Mock
+  private CertificateRelationEntityRepository certificateRelationEntityRepository;
+  @Mock
+  private CertificateRelationTypeEntityRepository certificateRelationTypeEntityRepository;
 
   @Test
   void shouldMapCertificateCorrectlyWhenCreatingNewEntity() {
@@ -78,5 +91,59 @@ class CertificateEntityMapperTest {
 
     final var result = certificateEntityMapper.map(message);
     assertEquals(existingEntity, result);
+  }
+
+  @Test
+  void shouldCreateCertificateRelationIfParentIdAndTypePresentAndNotExists() {
+    final var message = TestDataPseudonymized.draftPseudonymizedMessageBuilder()
+        .certificateRelationParentId(CERTIFICATE_PARENT_ID)
+        .certificateRelationParentType(CERTIFICATE_PARENT_TYPE)
+        .build();
+    final var parentEntity = mock(CertificateEntity.class);
+    final var relationTypeEntity = CertificateRelationTypeEntity.builder()
+        .relationType(CERTIFICATE_PARENT_TYPE)
+        .build();
+    final var newEntity = CertificateEntity.builder()
+        .certificateId(message.getCertificateId())
+        .build();
+
+    when(certificateEntityRepository.findByCertificateId(message.getCertificateId())).thenReturn(
+        Optional.of(newEntity));
+    when(certificateEntityRepository.findByCertificateId(CERTIFICATE_PARENT_ID)).thenReturn(
+        Optional.of(parentEntity));
+    when(certificateRelationTypeEntityRepository
+        .findByRelationType(CERTIFICATE_PARENT_TYPE))
+        .thenReturn(Optional.of(relationTypeEntity));
+    when(certificateRelationEntityRepository.findAll()).thenReturn(
+        java.util.Collections.emptyList());
+
+    certificateEntityMapper.map(message);
+
+    verify(certificateRelationEntityRepository).save(
+        argThat(
+            rel -> rel.getParentCertificate().equals(parentEntity)
+                && rel.getChildCertificate().equals(newEntity)
+                && rel.getRelationType().equals(relationTypeEntity)
+        )
+    );
+  }
+
+  @Test
+  void shouldNotCreateCertificateRelationIfParentIdOrTypeMissing() {
+    final var message = TestDataPseudonymized.draftPseudonymizedMessageBuilder()
+        .certificateRelationParentId(null)
+        .certificateRelationParentType(null)
+        .build();
+    
+    final var newEntity = CertificateEntity.builder()
+        .certificateId(message.getCertificateId())
+        .build();
+
+    when(certificateEntityRepository.findByCertificateId(message.getCertificateId())).thenReturn(
+        Optional.of(newEntity));
+
+    certificateEntityMapper.map(message);
+
+    verify(certificateRelationEntityRepository, never()).save(any());
   }
 }

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/EventMapperTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/EventMapperTest.java
@@ -15,6 +15,7 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.ent
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.EventEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.EventTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.OriginEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RoleEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.SessionEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.UnitEntity;
@@ -22,6 +23,7 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.ent
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CareProviderRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.EventTypeRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.OriginRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.RecipientRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.RoleRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.SessionRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.UnitRepository;
@@ -50,11 +52,13 @@ class EventMapperTest {
   @Mock
   private RoleRepository roleRepository;
   @Mock
+  private RecipientRepository recipientRepository;
+  @Mock
   private CertificateEntityMapper certificateEntityMapper;
 
   @Test
   void shouldMapPseudonymizedAnalyticsMessageCorrectly() {
-    final var message = TestDataPseudonymized.draftPseudonymizedMessageBuilder().build();
+    final var message = TestDataPseudonymized.sentPseudonymizedMessageBuilder().build();
 
     final var expectedCertificate = mock(CertificateEntity.class);
     final var expectedUnit = mock(UnitEntity.class);
@@ -64,6 +68,7 @@ class EventMapperTest {
     final var expectedOrigin = mock(OriginEntity.class);
     final var expectedEventType = mock(EventTypeEntity.class);
     final var expectedRole = mock(RoleEntity.class);
+    final var expectedRecipient = mock(RecipientEntity.class);
 
     when(certificateEntityMapper.map(message)).thenReturn(expectedCertificate);
     when(unitRepository.findOrCreate(message.getCertificateUnitId())).thenReturn(expectedUnit);
@@ -75,6 +80,8 @@ class EventMapperTest {
     when(eventTypeRepository.findOrCreate(message.getEventMessageType())).thenReturn(
         expectedEventType);
     when(roleRepository.findOrCreate(message.getEventRole())).thenReturn(expectedRole);
+    when(recipientRepository.findOrCreate(message.getRecipientId())).thenReturn(expectedRecipient);
+
     final var expected = EventEntity.builder()
         .certificate(expectedCertificate)
         .unit(expectedUnit)
@@ -85,6 +92,7 @@ class EventMapperTest {
         .origin(expectedOrigin)
         .eventType(expectedEventType)
         .role(expectedRole)
+        .recipient(expectedRecipient)
         .messageId(message.getMessageId())
         .build();
 

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/EventMapperTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/EventMapperTest.java
@@ -3,8 +3,11 @@ package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.en
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_MESSAGE_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataEntities.certificateRelationEntity;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataEntities.sentEventEntityBuilder;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataPseudonymized.sentPseudonymizedMessageBuilder;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,6 +24,7 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.ent
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.UnitEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.UserEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CareProviderRepository;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.CertificateRelationEntityRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.EventTypeRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.OriginRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.RecipientRepository;
@@ -28,9 +32,6 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.rep
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.SessionRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.UnitRepository;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository.UserRepository;
-import se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants;
-import se.inera.intyg.certificateanalyticsservice.testdata.TestDataEntities;
-import se.inera.intyg.certificateanalyticsservice.testdata.TestDataPseudonymized;
 
 @ExtendWith(MockitoExtension.class)
 class EventMapperTest {
@@ -55,10 +56,12 @@ class EventMapperTest {
   private RecipientRepository recipientRepository;
   @Mock
   private CertificateEntityMapper certificateEntityMapper;
+  @Mock
+  private CertificateRelationEntityRepository certificateRelationEntityRepository;
 
   @Test
   void shouldMapPseudonymizedAnalyticsMessageCorrectly() {
-    final var message = TestDataPseudonymized.sentPseudonymizedMessageBuilder().build();
+    final var message = sentPseudonymizedMessageBuilder().build();
 
     final var expectedCertificate = mock(CertificateEntity.class);
     final var expectedUnit = mock(UnitEntity.class);
@@ -104,22 +107,11 @@ class EventMapperTest {
 
   @Test
   void shouldMapEventEntityToDomainCorrectly() {
-    final var entity = EventEntity.builder()
-        .certificate(TestDataEntities.certificateEntity())
-        .unit(TestDataEntities.unitEntity())
-        .careProvider(TestDataEntities.careProviderEntity())
-        .user(TestDataEntities.userEntity())
-        .session(TestDataEntities.sessionEntity())
-        .timestamp(TestDataConstants.TIMESTAMP)
-        .origin(TestDataEntities.originEntity())
-        .eventType(TestDataEntities.eventTypeEntity())
-        .role(TestDataEntities.roleEntity())
-        .messageId(HASHED_MESSAGE_ID)
-        .build();
-
-    final var expected = TestDataPseudonymized.draftPseudonymizedMessageBuilder().build();
-    final var result = eventMapper.toDomain(entity);
-
-    assertEquals(expected, result);
+    final var expected = sentPseudonymizedMessageBuilder().build();
+    final var entity = sentEventEntityBuilder().build();
+    when(certificateRelationEntityRepository.findAll())
+        .thenReturn(List.of(certificateRelationEntity()));
+    final var actual = eventMapper.toDomain(entity);
+    assertEquals(expected, actual);
   }
 }

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/RecipientEntityMapperTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/RecipientEntityMapperTest.java
@@ -1,0 +1,21 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
+import se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants;
+
+class RecipientEntityMapperTest {
+
+  @Test
+  void shouldMapRecipientCorrectly() {
+    final var expected = RecipientEntity.builder()
+        .recipient(TestDataConstants.RECIPIENT)
+        .build();
+
+    final var result = RecipientEntityMapper.map(TestDataConstants.RECIPIENT);
+
+    assertEquals(expected, result);
+  }
+}

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/UserEntityMapperTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/entity/mapper/UserEntityMapperTest.java
@@ -11,9 +11,9 @@ class UserEntityMapperTest {
   @Test
   void shouldMapStaffIdCorrectly() {
     final var expected = UserEntity.builder()
-        .userId(TestDataConstants.STAFF_ID)
+        .userId(TestDataConstants.USER_ID)
         .build();
-    final var result = UserEntityMapper.map(TestDataConstants.STAFF_ID);
+    final var result = UserEntityMapper.map(TestDataConstants.USER_ID);
     assertEquals(expected, result);
   }
 }

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/RecipientRepositoryTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/persistance/repository/RecipientRepositoryTest.java
@@ -1,0 +1,58 @@
+package se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
+import se.inera.intyg.certificateanalyticsservice.testdata.TestDataEntities;
+
+@ExtendWith(MockitoExtension.class)
+class RecipientRepositoryTest {
+
+  @InjectMocks
+  private RecipientRepository recipientRepository;
+  @Mock
+  private RecipientEntityRepository recipientEntityRepository;
+
+  @Test
+  void shouldCreateNewRecipientEntityIfNotExists() {
+    final var recipient = TestDataEntities.recipientEntity();
+    final var savedRecipient = mock(RecipientEntity.class);
+    when(recipientEntityRepository.findByRecipient(recipient.getRecipient())).thenReturn(
+        Optional.empty());
+    when(recipientEntityRepository.save(recipient)).thenReturn(savedRecipient);
+
+    final var result = recipientRepository.findOrCreate(recipient.getRecipient());
+
+    assertEquals(savedRecipient, result);
+  }
+
+  @Test
+  void shouldFindExistingRecipientEntity() {
+    final var recipientName = TestDataEntities.recipientEntity().getRecipient();
+    final var entity = mock(RecipientEntity.class);
+    when(recipientEntityRepository.findByRecipient(recipientName)).thenReturn(Optional.of(entity));
+
+    final var result = recipientRepository.findOrCreate(recipientName);
+
+    assertEquals(entity, result);
+  }
+
+  @Test
+  void shouldReturnNullIfRecipientIsNull() {
+    assertNull(recipientRepository.findOrCreate(null));
+  }
+
+  @Test
+  void shouldReturnNullIfRecipientIsEmpty() {
+    assertNull(recipientRepository.findOrCreate(" "));
+  }
+}

--- a/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/pseudonymization/PseudonymizationTokenGeneratorTest.java
+++ b/certificate-analytics-service/app/src/test/java/se/inera/intyg/certificateanalyticsservice/infrastructure/pseudonymization/PseudonymizationTokenGeneratorTest.java
@@ -66,6 +66,16 @@ class PseudonymizationTokenGeneratorTest {
     }
 
     @Test
+    void shallGeneratePseudonymizedParentCertificateIdThatIsTheSameOverTime() {
+      final var expected = "3CMu4xpRBVNUVQ9ARZKY8Q";
+      final var parentCertificateId = "parentCertificateId";
+
+      final var actual = pseudonymizationTokenGenerator.parentCertificateId(parentCertificateId);
+
+      assertEquals(expected, actual);
+    }
+
+    @Test
     void shallGeneratePseudonymizedSessionIdThatIsTheSameOverTime() {
       final var expected = "nTxVe__MOq5J6sbFWhRweg";
       final var sessionId = "sessionId";
@@ -125,6 +135,18 @@ class PseudonymizationTokenGeneratorTest {
     }
 
     @Test
+    void shallGenerateSamePseudonymizedParentCertificateIdFromSameValue() {
+      final var parentCertificateId = "parentCertificateId";
+
+      final var parentCertificateIdOne = pseudonymizationTokenGenerator.parentCertificateId(
+          parentCertificateId);
+      final var parentCertificateIdTwo = pseudonymizationTokenGenerator.parentCertificateId(
+          parentCertificateId);
+
+      assertEquals(parentCertificateIdOne, parentCertificateIdTwo);
+    }
+
+    @Test
     void shallGenerateSamePseudonymizedSessionIdFromSameValue() {
       final var sessionId = "sessionId";
 
@@ -178,6 +200,26 @@ class PseudonymizationTokenGeneratorTest {
           "Tokens for same value across types should be unique: %s".formatted(tokens)
       );
     }
+
+    @Test
+    void shallGenerateSameTokenForSameValueForCertificateIdTypes() {
+      final var value = "samevalue";
+
+      final var certificateIdToken = pseudonymizationTokenGenerator.certificateId(value);
+      final var parentCertificateIdToken = pseudonymizationTokenGenerator.parentCertificateId(
+          value);
+
+      final var tokens = List.of(
+          certificateIdToken,
+          parentCertificateIdToken
+      );
+
+      final var uniqueTokens = tokens.stream().distinct().count();
+
+      assertEquals(1, uniqueTokens,
+          "Tokens for same value across certificateId types should be same: %s".formatted(tokens)
+      );
+    }
   }
 
   /**
@@ -220,6 +262,19 @@ class PseudonymizationTokenGeneratorTest {
       final var certificateIdTwo = pseudonymizationTokenGenerator.certificateId(certificateId);
 
       assertNotEquals(certificateIdOne, certificateIdTwo);
+    }
+
+    @Test
+    void shallGenerateDifferentPseudonymizedParentCertificateIdFromSameValueButDifferentContext() {
+      final var parentCertificateId = "parentCertificateId";
+
+      final var parentCertificateIdOne = pseudonymizationTokenGenerator.parentCertificateId(
+          parentCertificateId);
+      ReflectionTestUtils.setField(pseudonymizationTokenGenerator, "context", "analytics-dev");
+      final var parentCertificateIdTwo = pseudonymizationTokenGenerator.parentCertificateId(
+          parentCertificateId);
+
+      assertNotEquals(parentCertificateIdOne, parentCertificateIdTwo);
     }
 
     @Test

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataConstants.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataConstants.java
@@ -28,6 +28,7 @@ public final class TestDataConstants {
   public static final String EVENT_TYPE_CERTIFICATE_SENT = "CERTIFICATE_SENT";
   public static final String HASHED_MESSAGE_ID = "M-P4rHB5bMLzQQrCTlprRA";
   public static final String HASHED_CERTIFICATE_ID = "Xsg4sVYtNq_zMGU_wWrJgw";
+  public static final String HASHED_CERTIFICATE_PARENT_ID = "VDJhjt69htHErDZl21BM7w";
   public static final String HASHED_PATIENT_ID = "v4WI46Ymy08FKdhJJFDocw";
   public static final String EVENT_TIMESTAMP = "2025-09-29T17:49:58.616648";
   public static final String HASHED_SESSION_ID = "GRmmGqqMdm6mFSy9ZCfT5w";

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataConstants.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataConstants.java
@@ -10,24 +10,28 @@ public final class TestDataConstants {
   public static final String CERTIFICATE_ID = "78a0a279-1197-4cc7-bf6a-899cb5034053";
   public static final String CERTIFICATE_TYPE = "fk7210";
   public static final String CERTIFICATE_TYPE_VERSION = "1.0";
+  public static final String CERTIFICATE_PARENT_ID = "9a6e4f30-3a4e-4637-be91-ee5213b89bad";
+  public static final String CERTIFICATE_PARENT_TYPE = "REPLACED";
   public static final String UNIT_ID = "TSTNMT2321000156-ALMC";
   public static final String CARE_PROVIDER_ID = "TSTNMT2321000156-ALFA";
-  public static final String STAFF_ID = "TSTNMT2321000156-DRAA";
+  public static final String USER_ID = "TSTNMT2321000156-DRAA";
   public static final String PATIENT_ID = "19401130-6125";
   public static final String ROLE = "LAKARE";
   public static final String ORIGIN = "NORMAL";
   public static final String SESSION_ID = "2d02bc34-41f1-42b7-9964-d0659bf369c8";
   public static final LocalDateTime TIMESTAMP = LocalDateTime.of(2025, 9, 29, 17, 49, 58,
       616648000);
+  public static final String RECIPIENT = "FKASSA";
   public static final String SCHEMA_VERSION = "v1";
   public static final String TYPE_ANALYTICS_EVENT = "certificate.analytics.event";
   public static final String EVENT_TYPE_DRAFT_CREATED = "DRAFT_CREATED";
+  public static final String EVENT_TYPE_CERTIFICATE_SENT = "CERTIFICATE_SENT";
   public static final String HASHED_MESSAGE_ID = "M-P4rHB5bMLzQQrCTlprRA";
   public static final String HASHED_CERTIFICATE_ID = "Xsg4sVYtNq_zMGU_wWrJgw";
   public static final String HASHED_PATIENT_ID = "v4WI46Ymy08FKdhJJFDocw";
   public static final String EVENT_TIMESTAMP = "2025-09-29T17:49:58.616648";
   public static final String HASHED_SESSION_ID = "GRmmGqqMdm6mFSy9ZCfT5w";
-  public static final String HASHED_STAFF_ID = "IlXi3vfzsRwLaNRjpqYxOQ";
+  public static final String HASHED_USER_ID = "IlXi3vfzsRwLaNRjpqYxOQ";
 
   private TestDataConstants() {
   }

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataEntities.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataEntities.java
@@ -3,6 +3,7 @@ package se.inera.intyg.certificateanalyticsservice.testdata;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CARE_PROVIDER_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE_VERSION;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_CERTIFICATE_PARENT_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_PATIENT_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_USER_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ORIGIN;
@@ -13,8 +14,12 @@ import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConsta
 
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CareProviderEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateEntity.CertificateEntityBuilder;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateRelationTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.CertificateTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.EventEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.EventEntity.EventEntityBuilder;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.EventTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.OriginEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.PatientEntity;
@@ -30,6 +35,21 @@ public class TestDataEntities {
     throw new IllegalStateException("Utility class");
   }
 
+  public static EventEntityBuilder sentEventEntityBuilder() {
+    return EventEntity.builder()
+        .certificate(certificateEntity().build())
+        .messageId(TestDataConstants.HASHED_MESSAGE_ID)
+        .timestamp(TIMESTAMP)
+        .eventType(eventTypeEntity())
+        .role(roleEntity())
+        .unit(unitEntity())
+        .careProvider(careProviderEntity())
+        .user(userEntity())
+        .session(sessionEntity())
+        .origin(originEntity())
+        .recipient(recipientEntity());
+  }
+
   public static CertificateTypeEntity certificateTypeEntity() {
     return CertificateTypeEntity.builder()
         .certificateType(CERTIFICATE_TYPE)
@@ -37,14 +57,13 @@ public class TestDataEntities {
         .build();
   }
 
-  public static CertificateEntity certificateEntity() {
+  public static CertificateEntityBuilder certificateEntity() {
     return CertificateEntity.builder()
         .certificateId(TestDataConstants.HASHED_CERTIFICATE_ID)
         .certificateType(certificateTypeEntity())
         .patient(patientEntity())
         .unit(unitEntity())
-        .careProvider(careProviderEntity())
-        .build();
+        .careProvider(careProviderEntity());
   }
 
   public static PatientEntity patientEntity() {
@@ -62,21 +81,6 @@ public class TestDataEntities {
   public static UnitEntity unitEntity() {
     return UnitEntity.builder()
         .hsaId(UNIT_ID)
-        .build();
-  }
-
-  public static EventEntity createdEventEntity() {
-    return EventEntity.builder()
-        .certificate(certificateEntity())
-        .unit(unitEntity())
-        .careProvider(careProviderEntity())
-        .user(userEntity())
-        .session(sessionEntity())
-        .timestamp(TIMESTAMP)
-        .origin(originEntity())
-        .eventType(eventTypeEntity())
-        .role(roleEntity())
-        .messageId(TestDataConstants.HASHED_MESSAGE_ID)
         .build();
   }
 
@@ -100,7 +104,7 @@ public class TestDataEntities {
 
   public static EventTypeEntity eventTypeEntity() {
     return EventTypeEntity.builder()
-        .eventType(TestDataConstants.EVENT_TYPE_DRAFT_CREATED)
+        .eventType(TestDataConstants.EVENT_TYPE_CERTIFICATE_SENT)
         .build();
   }
 
@@ -113,6 +117,22 @@ public class TestDataEntities {
   public static RecipientEntity recipientEntity() {
     return RecipientEntity.builder()
         .recipient(RECIPIENT)
+        .build();
+  }
+
+  public static CertificateRelationEntity certificateRelationEntity() {
+    return CertificateRelationEntity.builder()
+        .parentCertificate(
+            certificateEntity()
+                .certificateId(HASHED_CERTIFICATE_PARENT_ID)
+                .build()
+        )
+        .childCertificate(certificateEntity().build())
+        .relationType(
+            CertificateRelationTypeEntity.builder()
+                .relationType(TestDataConstants.CERTIFICATE_PARENT_TYPE)
+                .build()
+        )
         .build();
   }
 }

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataEntities.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataEntities.java
@@ -4,8 +4,9 @@ import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConsta
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE_VERSION;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_PATIENT_ID;
-import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_STAFF_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_USER_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ORIGIN;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.RECIPIENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ROLE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.TIMESTAMP;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.UNIT_ID;
@@ -17,6 +18,7 @@ import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.ent
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.EventTypeEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.OriginEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.PatientEntity;
+import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RecipientEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.RoleEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.SessionEntity;
 import se.inera.intyg.certificateanalyticsservice.infrastructure.persistance.entity.UnitEntity;
@@ -80,7 +82,7 @@ public class TestDataEntities {
 
   public static UserEntity userEntity() {
     return UserEntity.builder()
-        .userId(HASHED_STAFF_ID)
+        .userId(HASHED_USER_ID)
         .build();
   }
 
@@ -105,6 +107,12 @@ public class TestDataEntities {
   public static RoleEntity roleEntity() {
     return RoleEntity.builder()
         .role(ROLE)
+        .build();
+  }
+
+  public static RecipientEntity recipientEntity() {
+    return RecipientEntity.builder()
+        .recipient(RECIPIENT)
         .build();
   }
 }

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataMessages.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataMessages.java
@@ -2,19 +2,23 @@ package se.inera.intyg.certificateanalyticsservice.testdata;
 
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CARE_PROVIDER_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_PARENT_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_PARENT_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE_VERSION;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TIMESTAMP;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TYPE_CERTIFICATE_SENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TYPE_DRAFT_CREATED;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.MESSAGE_ID_CREATED;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ORIGIN;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.PATIENT_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.RECIPIENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ROLE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.SCHEMA_VERSION;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.SESSION_ID;
-import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.STAFF_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.TYPE_ANALYTICS_EVENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.UNIT_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.USER_ID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -23,10 +27,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.UncheckedIOException;
 import java.time.LocalDateTime;
+import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateRelationV1;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateV1;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateV1.CertificateAnalyticsEventCertificateV1Builder;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventMessageV1;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventMessageV1.CertificateAnalyticsEventMessageV1Builder;
+import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventRecipientV1;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventV1;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventV1.CertificateAnalyticsEventV1Builder;
 
@@ -54,6 +60,86 @@ public class TestDataMessages {
     }
   }
 
+  public static CertificateAnalyticsEventMessageV1Builder replaceMessageBuilder() {
+    return CertificateAnalyticsEventMessageV1.builder()
+        .messageId(MESSAGE_ID_CREATED)
+        .type(TYPE_ANALYTICS_EVENT)
+        .schemaVersion(SCHEMA_VERSION)
+        .certificate(
+            certificateBuilder()
+                .id(CERTIFICATE_ID)
+                .unitId(UNIT_ID)
+                .careProviderId(CARE_PROVIDER_ID)
+                .patientId(PATIENT_ID)
+                .type(CERTIFICATE_TYPE)
+                .typeVersion(CERTIFICATE_TYPE_VERSION)
+                .parent(
+                    CertificateAnalyticsEventCertificateRelationV1.builder()
+                        .id(CERTIFICATE_PARENT_ID)
+                        .type(CERTIFICATE_PARENT_TYPE)
+                        .build()
+                )
+                .build()
+        )
+        .event(
+            eventBuilder()
+                .messageType(EVENT_TYPE_DRAFT_CREATED)
+                .timestamp(LocalDateTime.parse(EVENT_TIMESTAMP))
+                .userId(USER_ID)
+                .role(ROLE)
+                .unitId(UNIT_ID)
+                .careProviderId(CARE_PROVIDER_ID)
+                .sessionId(SESSION_ID)
+                .origin(ORIGIN)
+                .build()
+        )
+        .recipient(
+            CertificateAnalyticsEventRecipientV1.builder()
+                .id(RECIPIENT)
+                .build()
+        );
+  }
+
+  public static CertificateAnalyticsEventMessageV1Builder sentMessageBuilder() {
+    return CertificateAnalyticsEventMessageV1.builder()
+        .messageId(MESSAGE_ID_CREATED)
+        .type(TYPE_ANALYTICS_EVENT)
+        .schemaVersion(SCHEMA_VERSION)
+        .certificate(
+            certificateBuilder()
+                .id(CERTIFICATE_ID)
+                .unitId(UNIT_ID)
+                .careProviderId(CARE_PROVIDER_ID)
+                .patientId(PATIENT_ID)
+                .type(CERTIFICATE_TYPE)
+                .typeVersion(CERTIFICATE_TYPE_VERSION)
+                .parent(
+                    CertificateAnalyticsEventCertificateRelationV1.builder()
+                        .id(CERTIFICATE_PARENT_ID)
+                        .type(CERTIFICATE_PARENT_TYPE)
+                        .build()
+                )
+                .build()
+        )
+        .event(
+            eventBuilder()
+                .messageType(EVENT_TYPE_CERTIFICATE_SENT)
+                .timestamp(LocalDateTime.parse(EVENT_TIMESTAMP))
+                .userId(USER_ID)
+                .role(ROLE)
+                .unitId(UNIT_ID)
+                .careProviderId(CARE_PROVIDER_ID)
+                .sessionId(SESSION_ID)
+                .origin(ORIGIN)
+                .build()
+        )
+        .recipient(
+            CertificateAnalyticsEventRecipientV1.builder()
+                .id(RECIPIENT)
+                .build()
+        );
+  }
+
   public static CertificateAnalyticsEventMessageV1Builder draftMessageBuilder() {
     return CertificateAnalyticsEventMessageV1.builder()
         .messageId(MESSAGE_ID_CREATED)
@@ -73,7 +159,7 @@ public class TestDataMessages {
             eventBuilder()
                 .messageType(EVENT_TYPE_DRAFT_CREATED)
                 .timestamp(LocalDateTime.parse(EVENT_TIMESTAMP))
-                .userId(STAFF_ID)
+                .userId(USER_ID)
                 .role(ROLE)
                 .unitId(UNIT_ID)
                 .careProviderId(CARE_PROVIDER_ID)
@@ -96,7 +182,7 @@ public class TestDataMessages {
   private static CertificateAnalyticsEventV1Builder eventBuilder() {
     return CertificateAnalyticsEventV1.builder()
         .timestamp(LocalDateTime.parse(EVENT_TIMESTAMP))
-        .userId(STAFF_ID)
+        .userId(USER_ID)
         .role(ROLE)
         .unitId(UNIT_ID)
         .careProviderId(CARE_PROVIDER_ID)

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataMessages.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataMessages.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.UncheckedIOException;
 import java.time.LocalDateTime;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateRelationV1;
+import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateRelationV1.CertificateAnalyticsEventCertificateRelationV1Builder;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateV1;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventCertificateV1.CertificateAnalyticsEventCertificateV1Builder;
 import se.inera.intyg.certificateanalyticsservice.application.messages.model.v1.CertificateAnalyticsEventMessageV1;
@@ -66,20 +67,7 @@ public class TestDataMessages {
         .type(TYPE_ANALYTICS_EVENT)
         .schemaVersion(SCHEMA_VERSION)
         .certificate(
-            certificateBuilder()
-                .id(CERTIFICATE_ID)
-                .unitId(UNIT_ID)
-                .careProviderId(CARE_PROVIDER_ID)
-                .patientId(PATIENT_ID)
-                .type(CERTIFICATE_TYPE)
-                .typeVersion(CERTIFICATE_TYPE_VERSION)
-                .parent(
-                    CertificateAnalyticsEventCertificateRelationV1.builder()
-                        .id(CERTIFICATE_PARENT_ID)
-                        .type(CERTIFICATE_PARENT_TYPE)
-                        .build()
-                )
-                .build()
+            sentCertificateBuilder().build()
         )
         .event(
             eventBuilder()
@@ -106,20 +94,7 @@ public class TestDataMessages {
         .type(TYPE_ANALYTICS_EVENT)
         .schemaVersion(SCHEMA_VERSION)
         .certificate(
-            certificateBuilder()
-                .id(CERTIFICATE_ID)
-                .unitId(UNIT_ID)
-                .careProviderId(CARE_PROVIDER_ID)
-                .patientId(PATIENT_ID)
-                .type(CERTIFICATE_TYPE)
-                .typeVersion(CERTIFICATE_TYPE_VERSION)
-                .parent(
-                    CertificateAnalyticsEventCertificateRelationV1.builder()
-                        .id(CERTIFICATE_PARENT_ID)
-                        .type(CERTIFICATE_PARENT_TYPE)
-                        .build()
-                )
-                .build()
+            sentCertificateBuilder().build()
         )
         .event(
             eventBuilder()
@@ -138,6 +113,25 @@ public class TestDataMessages {
                 .id(RECIPIENT)
                 .build()
         );
+  }
+
+  public static CertificateAnalyticsEventCertificateV1Builder sentCertificateBuilder() {
+    return certificateBuilder()
+        .id(CERTIFICATE_ID)
+        .unitId(UNIT_ID)
+        .careProviderId(CARE_PROVIDER_ID)
+        .patientId(PATIENT_ID)
+        .type(CERTIFICATE_TYPE)
+        .typeVersion(CERTIFICATE_TYPE_VERSION)
+        .parent(
+            replacedRelationBuilder().build()
+        );
+  }
+
+  public static CertificateAnalyticsEventCertificateRelationV1Builder replacedRelationBuilder() {
+    return CertificateAnalyticsEventCertificateRelationV1.builder()
+        .id(CERTIFICATE_PARENT_ID)
+        .type(CERTIFICATE_PARENT_TYPE);
   }
 
   public static CertificateAnalyticsEventMessageV1Builder draftMessageBuilder() {

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataPseudonymized.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataPseudonymized.java
@@ -1,12 +1,14 @@
 package se.inera.intyg.certificateanalyticsservice.testdata;
 
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CARE_PROVIDER_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_PARENT_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE_VERSION;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TIMESTAMP;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TYPE_CERTIFICATE_SENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TYPE_DRAFT_CREATED;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_CERTIFICATE_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_CERTIFICATE_PARENT_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_MESSAGE_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_PATIENT_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_SESSION_ID;
@@ -62,6 +64,8 @@ public class TestDataPseudonymized {
         .certificatePatientId(HASHED_PATIENT_ID)
         .certificateUnitId(UNIT_ID)
         .certificateCareProviderId(CARE_PROVIDER_ID)
+        .certificateRelationParentId(HASHED_CERTIFICATE_PARENT_ID)
+        .certificateRelationParentType(CERTIFICATE_PARENT_TYPE)
         .recipientId(RECIPIENT);
   }
 }

--- a/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataPseudonymized.java
+++ b/certificate-analytics-service/app/src/testFixtures/java/se/inera/intyg/certificateanalyticsservice/testdata/TestDataPseudonymized.java
@@ -4,13 +4,15 @@ import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConsta
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.CERTIFICATE_TYPE_VERSION;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TIMESTAMP;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TYPE_CERTIFICATE_SENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.EVENT_TYPE_DRAFT_CREATED;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_CERTIFICATE_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_MESSAGE_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_PATIENT_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_SESSION_ID;
-import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_STAFF_ID;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.HASHED_USER_ID;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ORIGIN;
+import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.RECIPIENT;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.ROLE;
 import static se.inera.intyg.certificateanalyticsservice.testdata.TestDataConstants.UNIT_ID;
 
@@ -29,7 +31,7 @@ public class TestDataPseudonymized {
         .messageId(HASHED_MESSAGE_ID)
         .eventTimestamp(LocalDateTime.parse(EVENT_TIMESTAMP))
         .eventMessageType(EVENT_TYPE_DRAFT_CREATED)
-        .eventUserId(HASHED_STAFF_ID)
+        .eventUserId(HASHED_USER_ID)
         .eventRole(ROLE)
         .eventUnitId(UNIT_ID)
         .eventCareProviderId(CARE_PROVIDER_ID)
@@ -41,5 +43,25 @@ public class TestDataPseudonymized {
         .certificatePatientId(HASHED_PATIENT_ID)
         .certificateUnitId(UNIT_ID)
         .certificateCareProviderId(CARE_PROVIDER_ID);
+  }
+
+  public static PseudonymizedAnalyticsMessageBuilder sentPseudonymizedMessageBuilder() {
+    return PseudonymizedAnalyticsMessage.builder()
+        .messageId(HASHED_MESSAGE_ID)
+        .eventTimestamp(LocalDateTime.parse(EVENT_TIMESTAMP))
+        .eventMessageType(EVENT_TYPE_CERTIFICATE_SENT)
+        .eventUserId(HASHED_USER_ID)
+        .eventRole(ROLE)
+        .eventUnitId(UNIT_ID)
+        .eventCareProviderId(CARE_PROVIDER_ID)
+        .eventOrigin(ORIGIN)
+        .eventSessionId(HASHED_SESSION_ID)
+        .certificateId(HASHED_CERTIFICATE_ID)
+        .certificateType(CERTIFICATE_TYPE)
+        .certificateTypeVersion(CERTIFICATE_TYPE_VERSION)
+        .certificatePatientId(HASHED_PATIENT_ID)
+        .certificateUnitId(UNIT_ID)
+        .certificateCareProviderId(CARE_PROVIDER_ID)
+        .recipientId(RECIPIENT);
   }
 }


### PR DESCRIPTION
Added implementation to handle additional properties in the analytics message:
1. recipient - used on events that send the certificate
2. relation - used on certificates that has a parent relationship to another certificate

Persists the recipient in a new dimension table.

Persists the relation in new dimension tables connected to certificate.

Integration tests to verify that the additions can be handled correctly from message to persist.